### PR TITLE
fix: resolve workflow runtime bugs blocking real-world usage

### DIFF
--- a/src/domain/issue.rs
+++ b/src/domain/issue.rs
@@ -1,4 +1,5 @@
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Issue {
@@ -11,6 +12,9 @@ pub struct Issue {
     pub url: Option<String>,
     pub notion_page_id: Option<String>,
     pub blockers: Vec<Blocker>,
+    /// Extra properties extracted from the tracker (e.g. "platform", "severity").
+    #[serde(default)]
+    pub extra: HashMap<String, String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,9 +8,9 @@ struct Cli {
     #[arg(default_value = "WORKFLOW.md")]
     workflow_path: PathBuf,
 
-    /// HTTP server port
-    #[arg(long, default_value_t = 8080)]
-    port: u16,
+    /// HTTP server port (overrides config; defaults to config value or 8080)
+    #[arg(long)]
+    port: Option<u16>,
 
     /// Output logs as JSON
     #[arg(long)]
@@ -22,11 +22,14 @@ async fn main() -> anyhow::Result<()> {
     let cli = Cli::parse();
 
     symposium::logging::init(cli.json_logs);
-    tracing::info!(workflow = %cli.workflow_path.display(), port = cli.port, "starting symposium");
 
     // Parse config
     let config = symposium::config::workflow::parse_workflow_file(&cli.workflow_path)?;
     tracing::info!("loaded config from {}", cli.workflow_path.display());
+
+    // CLI --port overrides config; config overrides default 8080
+    let port = cli.port.unwrap_or(config.server.port);
+    tracing::info!(workflow = %cli.workflow_path.display(), port, "starting symposium");
 
     // Create config watch channel
     let (config_tx, config_rx) = tokio::sync::watch::channel(config);
@@ -45,7 +48,7 @@ async fn main() -> anyhow::Result<()> {
     // Start HTTP server in background
     let server_state = state.clone();
     let server_handle = tokio::spawn(async move {
-        if let Err(e) = symposium::server::run(server_state, cli.port, Some(event_tx)).await {
+        if let Err(e) = symposium::server::run(server_state, port, Some(event_tx)).await {
             tracing::error!("server error: {e}");
         }
     });

--- a/src/orchestrator/tick.rs
+++ b/src/orchestrator/tick.rs
@@ -204,10 +204,10 @@ async fn run_worker(
     let ws = WorkspaceManager::new(config_rx.clone());
 
     // Ensure workspace exists (creates + runs after_create hook if new)
-    let workspace_dir = ws.ensure(&issue.identifier).await?;
+    let workspace_dir = ws.ensure(issue).await?;
 
     // Run before_run hook
-    ws.prepare(&issue.identifier).await?;
+    ws.prepare(issue, attempt).await?;
 
     // Build prompt from template
     let prompt_text = prompt::build_prompt(&config.prompt_template, issue, attempt)?;
@@ -222,7 +222,7 @@ async fn run_worker(
     let success = run_agent_attempt(&mut worker, &prompt_text, config.agent.max_turns).await?;
 
     // Run after_run hook
-    ws.finish(&issue.identifier, success).await?;
+    ws.finish(issue, success).await?;
 
     Ok(success)
 }

--- a/src/prompt/mod.rs
+++ b/src/prompt/mod.rs
@@ -12,15 +12,22 @@ pub fn build_prompt(template_str: &str, issue: &Issue, attempt: Option<u32>) -> 
         .parse(template_str)
         .map_err(|e| Error::Prompt(format!("failed to parse template: {e}")))?;
 
+    let mut issue_obj = liquid::object!({
+        "identifier": issue.identifier,
+        "title": issue.title,
+        "description": issue.description.as_deref().unwrap_or(""),
+        "status": issue.status,
+        "priority": issue.priority.as_deref().unwrap_or(""),
+        "url": issue.url.as_deref().unwrap_or(""),
+    });
+
+    // Merge extra properties so templates can use e.g. {{ issue.platform }}
+    for (key, val) in &issue.extra {
+        issue_obj.insert(key.clone().into(), liquid::model::Value::scalar(val.clone()));
+    }
+
     let mut globals = liquid::object!({
-        "issue": {
-            "identifier": issue.identifier,
-            "title": issue.title,
-            "description": issue.description.as_deref().unwrap_or(""),
-            "status": issue.status,
-            "priority": issue.priority.as_deref().unwrap_or(""),
-            "url": issue.url.as_deref().unwrap_or(""),
-        }
+        "issue": issue_obj,
     });
 
     if let Some(attempt) = attempt {
@@ -38,6 +45,7 @@ pub fn build_prompt(template_str: &str, issue: &Issue, attempt: Option<u32>) -> 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::collections::HashMap;
 
     #[test]
     fn test_basic_render() {
@@ -50,6 +58,7 @@ mod tests {
             url: Some("https://notion.so/page".to_string()),
             notion_page_id: Some("abc123".to_string()),
             blockers: vec![],
+            extra: HashMap::new(),
         };
 
         let template = "Work on {{ issue.identifier }}: {{ issue.title }}\n{{ issue.description }}";
@@ -68,11 +77,33 @@ mod tests {
             url: None,
             notion_page_id: None,
             blockers: vec![],
+            extra: HashMap::new(),
         };
 
         let template = "{% if attempt %}Retry #{{ attempt }}{% endif %} {{ issue.identifier }}";
         let result = build_prompt(template, &issue, Some(3)).unwrap();
         assert!(result.contains("Retry #3"));
         assert!(result.contains("TASK-456"));
+    }
+
+    #[test]
+    fn test_extra_properties_render() {
+        let mut extra = HashMap::new();
+        extra.insert("platform".to_string(), "iOS".to_string());
+        let issue = Issue {
+            identifier: "BUG-1".to_string(),
+            title: "Crash".to_string(),
+            description: None,
+            status: "On Deck".to_string(),
+            priority: Some("P1".to_string()),
+            url: None,
+            notion_page_id: None,
+            blockers: vec![],
+            extra,
+        };
+
+        let template = "Platform: {{ issue.platform }}";
+        let result = build_prompt(template, &issue, None).unwrap();
+        assert_eq!(result, "Platform: iOS");
     }
 }

--- a/src/tracker/notion.rs
+++ b/src/tracker/notion.rs
@@ -4,6 +4,7 @@ use crate::config::schema::TrackerConfig;
 use crate::domain::issue::Issue;
 use crate::error::{Error, Result};
 use serde_json::Value;
+use std::collections::{HashMap, HashSet};
 
 pub struct NotionTracker {
     client: McpClient,
@@ -74,20 +75,34 @@ impl NotionTracker {
         issues
     }
 
+    /// Strip known prefixes like `userDefined:` from property names.
+    fn resolve_property_name(name: &str) -> &str {
+        name.strip_prefix("userDefined:").unwrap_or(name)
+    }
+
     fn parse_issue_row(&self, row: &Value) -> Option<Issue> {
         let props = row.get("properties").or(Some(row));
 
-        let identifier = self.extract_property(props?, &self.config.property_id)?;
+        let id_prop = Self::resolve_property_name(&self.config.property_id);
+        let status_prop = Self::resolve_property_name(&self.config.property_status);
+        let priority_prop = Self::resolve_property_name(&self.config.property_priority);
+
+        let identifier = self.extract_property(props?, id_prop)?;
         let title = self
             .extract_property(props?, "Name")
             .or_else(|| self.extract_property(props?, "Title"))
             .unwrap_or_default();
         let status = self
-            .extract_property(props?, &self.config.property_status)
+            .extract_property(props?, status_prop)
             .unwrap_or_default();
-        let priority = self.extract_property(props?, &self.config.property_priority);
+        let priority = self.extract_property(props?, priority_prop);
         let page_id = row.get("id").and_then(|v| v.as_str()).map(String::from);
         let url = row.get("url").and_then(|v| v.as_str()).map(String::from);
+
+        // Collect extra properties not already mapped to known fields
+        let known: HashSet<&str> =
+            [id_prop, status_prop, priority_prop, "Name", "Title"].into();
+        let extra = self.extract_extra_properties(props?, &known);
 
         Some(Issue {
             identifier,
@@ -98,7 +113,28 @@ impl NotionTracker {
             url,
             notion_page_id: page_id,
             blockers: vec![],
+            extra,
         })
+    }
+
+    fn extract_extra_properties(
+        &self,
+        props: &Value,
+        known: &HashSet<&str>,
+    ) -> HashMap<String, String> {
+        let mut extra = HashMap::new();
+        if let Some(obj) = props.as_object() {
+            for (key, _) in obj {
+                if known.contains(key.as_str()) {
+                    continue;
+                }
+                if let Some(val) = self.extract_property(props, key) {
+                    // Use lowercase key so templates can use {{ issue.platform }}
+                    extra.insert(key.to_lowercase(), val);
+                }
+            }
+        }
+        extra
     }
 
     fn extract_property(&self, props: &Value, name: &str) -> Option<String> {

--- a/src/workspace/mod.rs
+++ b/src/workspace/mod.rs
@@ -2,7 +2,9 @@ pub mod hooks;
 pub mod safety;
 
 use crate::config::schema::ServiceConfig;
+use crate::domain::issue::Issue;
 use crate::error::{Error, Result};
+use crate::prompt;
 use std::path::PathBuf;
 use tokio::sync::watch;
 
@@ -29,20 +31,26 @@ impl WorkspaceManager {
         Ok(dir)
     }
 
+    /// Render a hook script through Liquid with issue context.
+    fn render_hook(&self, hook: &str, issue: &Issue, attempt: Option<u32>) -> Result<String> {
+        prompt::build_prompt(hook, issue, attempt)
+    }
+
     /// Ensure the workspace directory exists, run after_create hook if newly created.
-    pub async fn ensure(&self, issue_key: &str) -> Result<PathBuf> {
-        let dir = self.workspace_dir(issue_key)?;
+    pub async fn ensure(&self, issue: &Issue) -> Result<PathBuf> {
+        let dir = self.workspace_dir(&issue.identifier)?;
         let newly_created = !dir.exists();
 
         if newly_created {
             tokio::fs::create_dir_all(&dir).await.map_err(|e| {
                 Error::Workspace(format!("failed to create workspace {}: {e}", dir.display()))
             })?;
-            tracing::info!(issue_key, path = %dir.display(), "created workspace");
+            tracing::info!(issue_key = issue.identifier, path = %dir.display(), "created workspace");
 
             let config = self.config_rx.borrow().clone();
             if let Some(hook) = &config.hooks.after_create {
-                hooks::run_hook(hook, &dir, config.hooks.timeout()).await?;
+                let rendered = self.render_hook(hook, issue, None)?;
+                hooks::run_hook(&rendered, &dir, config.hooks.timeout()).await?;
             }
         }
 
@@ -50,26 +58,28 @@ impl WorkspaceManager {
     }
 
     /// Run the before_run hook in the workspace.
-    pub async fn prepare(&self, issue_key: &str) -> Result<PathBuf> {
-        let dir = self.workspace_dir(issue_key)?;
+    pub async fn prepare(&self, issue: &Issue, attempt: Option<u32>) -> Result<PathBuf> {
+        let dir = self.workspace_dir(&issue.identifier)?;
         let config = self.config_rx.borrow().clone();
         if let Some(hook) = &config.hooks.before_run {
-            hooks::run_hook(hook, &dir, config.hooks.timeout()).await?;
+            let rendered = self.render_hook(hook, issue, attempt)?;
+            hooks::run_hook(&rendered, &dir, config.hooks.timeout()).await?;
         }
         Ok(dir)
     }
 
     /// Run the after_run hook in the workspace.
-    pub async fn finish(&self, issue_key: &str, success: bool) -> Result<()> {
-        let dir = self.workspace_dir(issue_key)?;
+    pub async fn finish(&self, issue: &Issue, success: bool) -> Result<()> {
+        let dir = self.workspace_dir(&issue.identifier)?;
         let config = self.config_rx.borrow().clone();
         if let Some(hook) = &config.hooks.after_run {
+            let rendered = self.render_hook(hook, issue, None)?;
             let mut env = std::collections::HashMap::new();
             env.insert(
                 "RUN_SUCCESS".to_string(),
                 if success { "true" } else { "false" }.to_string(),
             );
-            hooks::run_hook_with_env(hook, &dir, config.hooks.timeout(), &env).await?;
+            hooks::run_hook_with_env(&rendered, &dir, config.hooks.timeout(), &env).await?;
         }
         Ok(())
     }


### PR DESCRIPTION
- Render hooks through Liquid so {{ issue.identifier }} expands in after_create/before_run/after_run scripts
- Strip userDefined: prefix from property_id config before Notion property lookup
- Use config server.port as fallback when --port CLI flag is omitted
- Add extra properties bag to Issue so arbitrary Notion fields like platform are available in templates