### PR TITLE
Align tracker property mapping with actual Notion schema

### DIFF
--- a/WORKFLOW.bugs.md
+++ b/WORKFLOW.bugs.md
@@ -1,0 +1,64 @@
+---
+tracker:
+  kind: notion
+  mcp_command: "npx -y @notionhq/notion-mcp-server"
+  database_id: "1cfb35e6-e67f-8168-bc1e-000b75bfd45a"
+  active_states: ["On Deck", "In Progress", "Backlog"]
+  terminal_states: ["Fixed", "Won't Fix", "Can't Fix", "No Longer Relevant", "Expected Behavior"]
+  property_id: "userDefined:ID"
+  property_title: "Task Name"
+  property_status: "Status"
+  property_priority: "Bug Priority"
+  property_description: "Notes"
+
+polling:
+  interval_ms: 30000
+
+workspace:
+  root: "~/symposium_workspaces/mail-bugs"
+
+hooks:
+  after_create: |
+    git clone git@github.com:makenotion/mail.git .
+    git checkout -b symposium/bug-{{ issue.identifier }}
+  before_run: |
+    git fetch origin main
+    git rebase origin/main
+
+agent:
+  max_concurrent_agents: 3
+  max_turns: 20
+
+codex:
+  command: "claude-code app-server"
+  turn_timeout_ms: 3600000
+  stall_timeout_ms: 300000
+
+server:
+  port: 8081
+---
+You are working on bug {{ issue.identifier }}: {{ issue.title }}.
+
+Platform: {{ issue.platform }}
+Severity: {{ issue.priority }}
+
+{{ issue.description }}
+
+You are working in the Notion Mail monorepo. Before starting, read `CLAUDE.md` at the repo root and the relevant subsystem `AGENTS.md` for the area you're working in.
+
+Key subsystem guides:
+- Mail backend: `services/mail/AGENTS.md`
+- Mail frontend: `mail-web/AGENTS.md`
+- iOS client: `mail-ios/AGENTS.md`
+
+This is a bug fix. Focus on:
+1. Reproducing the issue (read the bug description carefully)
+2. Finding the root cause
+3. Implementing the minimal fix
+4. Writing or updating tests to cover the regression
+
+Always build shared libraries first with `yarn build:lib` before building or running services.
+
+{% if attempt %}
+This is retry attempt {{ attempt }}. Review what happened in the previous attempt and continue from where you left off.
+{% endif %}

--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -25,8 +25,10 @@ pub struct TrackerConfig {
     pub active_states: Vec<String>,
     pub terminal_states: Vec<String>,
     pub property_id: String,
+    pub property_title: String,
     pub property_status: String,
     pub property_priority: String,
+    pub property_description: String,
 }
 
 impl Default for TrackerConfig {
@@ -38,8 +40,10 @@ impl Default for TrackerConfig {
             active_states: vec!["Todo".to_string(), "In Progress".to_string()],
             terminal_states: vec!["Done".to_string(), "Cancelled".to_string()],
             property_id: "ID".to_string(),
+            property_title: "Name".to_string(),
             property_status: "Status".to_string(),
             property_priority: "Priority".to_string(),
+            property_description: "Description".to_string(),
         }
     }
 }

--- a/src/tracker/notion.rs
+++ b/src/tracker/notion.rs
@@ -75,39 +75,34 @@ impl NotionTracker {
         issues
     }
 
-    /// Strip known prefixes like `userDefined:` from property names.
-    fn resolve_property_name(name: &str) -> &str {
-        name.strip_prefix("userDefined:").unwrap_or(name)
-    }
-
     fn parse_issue_row(&self, row: &Value) -> Option<Issue> {
         let props = row.get("properties").or(Some(row));
 
-        let id_prop = Self::resolve_property_name(&self.config.property_id);
-        let status_prop = Self::resolve_property_name(&self.config.property_status);
-        let priority_prop = Self::resolve_property_name(&self.config.property_priority);
+        let id_prop = self.config.property_id.as_str();
+        let title_prop = self.config.property_title.as_str();
+        let status_prop = self.config.property_status.as_str();
+        let priority_prop = self.config.property_priority.as_str();
+        let desc_prop = self.config.property_description.as_str();
 
         let identifier = self.extract_property(props?, id_prop)?;
-        let title = self
-            .extract_property(props?, "Name")
-            .or_else(|| self.extract_property(props?, "Title"))
-            .unwrap_or_default();
+        let title = self.extract_property(props?, title_prop).unwrap_or_default();
         let status = self
             .extract_property(props?, status_prop)
             .unwrap_or_default();
         let priority = self.extract_property(props?, priority_prop);
+        let description = self.extract_property(props?, desc_prop);
         let page_id = row.get("id").and_then(|v| v.as_str()).map(String::from);
         let url = row.get("url").and_then(|v| v.as_str()).map(String::from);
 
         // Collect extra properties not already mapped to known fields
         let known: HashSet<&str> =
-            [id_prop, status_prop, priority_prop, "Name", "Title"].into();
+            [id_prop, title_prop, status_prop, priority_prop, desc_prop].into();
         let extra = self.extract_extra_properties(props?, &known);
 
         Some(Issue {
             identifier,
             title,
-            description: None,
+            description,
             status,
             priority,
             url,


### PR DESCRIPTION
## Summary
- Add configurable `property_title` and `property_description` to `TrackerConfig` instead of hardcoding `"Name"`/`"Title"` fallbacks
- Remove `resolve_property_name` prefix stripping — the Notion MCP returns column names with the `userDefined:` prefix intact
- Extract description from the configured property into `Issue`
- Update `WORKFLOW.bugs.md` with correct data source collection ID and property names (`Task Name`, `Notes`) matching the actual Bugs database

## Test plan
- [x] `cargo test` — 18 tests pass
- [x] `cargo clippy` — clean
- [x] Validated column names against live database via Notion MCP query