### PR TITLE
Add HTTP MCP transport with OAuth 2.0 for notion-dev

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -191,6 +191,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
 name = "basic-toml"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -309,6 +315,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
+name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -353,10 +379,51 @@ dependencies = [
 ]
 
 [[package]]
+name = "dirs"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "displaydoc"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
+name = "encoding_rs"
+version = "0.8.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+dependencies = [
+ "cfg-if",
+]
 
 [[package]]
 name = "equivalent"
@@ -398,10 +465,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
 name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
@@ -472,15 +560,57 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 5.3.0",
+ "wasip2",
+]
+
+[[package]]
+name = "getrandom"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi",
+ "r-efi 6.0.0",
  "wasip2",
  "wasip3",
+]
+
+[[package]]
+name = "h2"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
 ]
 
 [[package]]
@@ -568,6 +698,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
+ "h2",
  "http",
  "http-body",
  "httparse",
@@ -577,6 +708,39 @@ dependencies = [
  "pin-utils",
  "smallvec",
  "tokio",
+ "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.27.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
+dependencies = [
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+]
+
+[[package]]
+name = "hyper-tls"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
+dependencies = [
+ "bytes",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
+ "tower-service",
 ]
 
 [[package]]
@@ -585,13 +749,23 @@ version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
+ "base64",
  "bytes",
+ "futures-channel",
+ "futures-util",
  "http",
  "http-body",
  "hyper",
+ "ipnet",
+ "libc",
+ "percent-encoding",
  "pin-project-lite",
+ "socket2",
+ "system-configuration",
  "tokio",
  "tower-service",
+ "tracing",
+ "windows-registry",
 ]
 
 [[package]]
@@ -619,10 +793,112 @@ dependencies = [
 ]
 
 [[package]]
+name = "icu_collections"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c6b649701667bbe825c3b7e6388cb521c23d88644678e83c0c4d0a621a34b43"
+dependencies = [
+ "displaydoc",
+ "potential_utf",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale_core"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edba7861004dd3714265b4db54a3c390e880ab658fec5f7db895fae2046b5bb6"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f6c8828b67bf8908d82127b2054ea1b4427ff0230ee9141c54251934ab1b599"
+dependencies = [
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7aedcccd01fc5fe81e6b489c15b247b8b0690feb23304303a9e560f37efc560a"
+
+[[package]]
+name = "icu_properties"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "020bfc02fe870ec3a66d93e677ccca0562506e5872c650f893269e08615d74ec"
+dependencies = [
+ "icu_collections",
+ "icu_locale_core",
+ "icu_properties_data",
+ "icu_provider",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "616c294cf8d725c6afcd8f55abc17c56464ef6211f9ed59cccffe534129c77af"
+
+[[package]]
+name = "icu_provider"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85962cf0ce02e1e0a629cc34e7ca3e373ce20dda4c4d7294bbd0bf1fdb59e614"
+dependencies = [
+ "displaydoc",
+ "icu_locale_core",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
 name = "id-arena"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
+name = "idna"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
+]
 
 [[package]]
 name = "indexmap"
@@ -663,6 +939,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "ipnet"
+version = "2.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
+
+[[package]]
+name = "iri-string"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c91338f0783edbd6195decb37bae672fd3b165faffb89bf7b9e6942f8b1a731a"
+dependencies = [
+ "memchr",
+ "serde",
+]
+
+[[package]]
+name = "is-docker"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "928bae27f42bc99b60d9ac7334e3a21d10ad8f1835a4e12ec3ec0464765ed1b3"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
+name = "is-wsl"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "173609498df190136aa7dea1a91db051746d339e18476eed5ca40521f02d7aa5"
+dependencies = [
+ "is-docker",
+ "once_cell",
 ]
 
 [[package]]
@@ -823,6 +1134,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "litemap"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
+
+[[package]]
 name = "lock_api"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -890,6 +1207,23 @@ dependencies = [
  "log",
  "wasi",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "native-tls"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "465500e14ea162429d264d44189adc38b199b62b1c21eea9f69e4b73cb03bbf2"
+dependencies = [
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
+ "tempfile",
 ]
 
 [[package]]
@@ -979,6 +1313,67 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "open"
+version = "5.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43bb73a7fa3799b198970490a51174027ba0d4ec504b03cd08caf513d40024bc"
+dependencies = [
+ "is-wsl",
+ "libc",
+ "pathdiff",
+]
+
+[[package]]
+name = "openssl"
+version = "0.10.75"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08838db121398ad17ab8531ce9de97b244589089e290a384c900cb9ff7434328"
+dependencies = [
+ "bitflags 2.11.0",
+ "cfg-if",
+ "foreign-types",
+ "libc",
+ "once_cell",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.111"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82cab2d520aa75e3c58898289429321eb788c3106963d0dc886ec7a5f4adc321"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
 name = "parking_lot"
 version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1000,6 +1395,12 @@ dependencies = [
  "smallvec",
  "windows-link",
 ]
+
+[[package]]
+name = "pathdiff"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
 
 [[package]]
 name = "percent-encoding"
@@ -1063,16 +1464,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
+name = "pkg-config"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+
+[[package]]
 name = "plain"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
+name = "potential_utf"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
+dependencies = [
+ "zerovec",
+]
+
+[[package]]
 name = "powerfmt"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
+
+[[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
 
 [[package]]
 name = "prettyplease"
@@ -1104,9 +1529,44 @@ dependencies = [
 
 [[package]]
 name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "rand"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+dependencies = [
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
+]
 
 [[package]]
 name = "redox_syscall"
@@ -1124,6 +1584,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce70a74e890531977d37e532c34d45e9055d2409ed08ddba14529471ed0be16"
 dependencies = [
  "bitflags 2.11.0",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
+dependencies = [
+ "getrandom 0.2.17",
+ "libredox",
+ "thiserror",
 ]
 
 [[package]]
@@ -1156,6 +1627,60 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
+name = "reqwest"
+version = "0.12.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+dependencies = [
+ "base64",
+ "bytes",
+ "encoding_rs",
+ "futures-core",
+ "h2",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-tls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "mime",
+ "native-tls",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-native-tls",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1166,6 +1691,39 @@ dependencies = [
  "libc",
  "linux-raw-sys",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls"
+version = "0.23.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
+dependencies = [
+ "once_cell",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
 ]
 
 [[package]]
@@ -1190,10 +1748,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "schannel"
+version = "0.1.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "891d81b926048e76efe18581bf793546b4c0eaf8448d72be8de2bbee5fd166e1"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "security-framework"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
+dependencies = [
+ "bitflags 2.11.0",
+ "core-foundation 0.10.1",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "semver"
@@ -1339,6 +1929,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "stable_deref_trait"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
 name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1351,21 +1947,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
 name = "symposium"
 version = "0.1.0"
 dependencies = [
  "anyhow",
  "askama",
  "axum",
+ "base64",
  "chrono",
  "clap",
+ "dirs",
  "liquid",
  "notify",
  "notify-debouncer-mini",
+ "open",
+ "rand",
  "regex",
+ "reqwest",
  "serde",
  "serde_json",
  "serde_yaml",
+ "sha2",
  "tempfile",
  "thiserror",
  "tokio",
@@ -1392,6 +2000,41 @@ name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+dependencies = [
+ "futures-core",
+]
+
+[[package]]
+name = "synstructure"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "system-configuration"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
+dependencies = [
+ "bitflags 2.11.0",
+ "core-foundation 0.9.4",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "tempfile"
@@ -1400,7 +2043,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "82a72c767771b47409d2345987fda8628641887d5466101319899796367354a0"
 dependencies = [
  "fastrand",
- "getrandom",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
@@ -1467,6 +2110,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinystr"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869"
+dependencies = [
+ "displaydoc",
+ "zerovec",
+]
+
+[[package]]
 name = "tokio"
 version = "1.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1492,6 +2145,26 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tokio-native-tls"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
+dependencies = [
+ "native-tls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls",
+ "tokio",
 ]
 
 [[package]]
@@ -1554,9 +2227,12 @@ checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
 dependencies = [
  "bitflags 2.11.0",
  "bytes",
+ "futures-util",
  "http",
  "http-body",
+ "iri-string",
  "pin-project-lite",
+ "tower",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -1650,6 +2326,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "try-lock"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
 name = "typenum"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1692,6 +2374,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
+name = "url"
+version = "2.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+ "serde",
+]
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
 name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1702,6 +2408,12 @@ name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version_check"
@@ -1717,6 +2429,15 @@ checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
 dependencies = [
  "same-file",
  "winapi-util",
+]
+
+[[package]]
+name = "want"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
+dependencies = [
+ "try-lock",
 ]
 
 [[package]]
@@ -1754,6 +2475,20 @@ dependencies = [
  "rustversion",
  "wasm-bindgen-macro",
  "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.64"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9c5522b3a28661442748e09d40924dfb9ca614b21c00d3fd135720e48b67db8"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "js-sys",
+ "once_cell",
+ "wasm-bindgen",
+ "web-sys",
 ]
 
 [[package]]
@@ -1823,6 +2558,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "web-sys"
+version = "0.3.91"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "854ba17bb104abfb26ba36da9729addc7ce7f06f5c0f90f3c391f8461cca21f9"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "winapi-util"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1871,6 +2616,17 @@ name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-registry"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
+dependencies = [
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
 
 [[package]]
 name = "windows-result"
@@ -2132,6 +2888,115 @@ dependencies = [
  "serde_json",
  "unicode-xid",
  "wasmparser",
+]
+
+[[package]]
+name = "writeable"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
+
+[[package]]
+name = "yoke"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72d6e5c6afb84d73944e5cedb052c4680d5657337201555f9f2a16b7406d4954"
+dependencies = [
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a789c6e490b576db9f7e6b6d661bcc9799f7c0ac8352f56ea20193b2681532e5"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f65c489a7071a749c849713807783f70672b28094011623e200cb86dcb835953"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "zerofrom"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
+name = "zeroize"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+
+[[package]]
+name = "zerotrie"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a59c17a5562d507e4b54960e8569ebee33bee890c70aa3fe7b97e85a9fd7851"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c28719294829477f525be0186d13efa9a3c602f7ec202ca9e353d310fb9a002"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,12 @@ anyhow = "1"
 regex = "1"
 askama = "0.12"
 tokio-util = { version = "0.7", features = ["time"] }
+reqwest = { version = "0.12", features = ["json"] }
+base64 = "0.22"
+rand = "0.9"
+sha2 = "0.10"
+open = "5"
+dirs = "6"
 
 [dev-dependencies]
 tempfile = "3"

--- a/WORKFLOW.bugs.md
+++ b/WORKFLOW.bugs.md
@@ -1,7 +1,7 @@
 ---
 tracker:
   kind: notion
-  mcp_command: "npx -y @notionhq/notion-mcp-server"
+  mcp_url: "https://mcp-dev.notion.com/readonly"
   database_id: "1cfb35e6-e67f-8168-bc1e-000b75bfd45a"
   active_states: ["On Deck", "In Progress", "Backlog"]
   terminal_states: ["Fixed", "Won't Fix", "Can't Fix", "No Longer Relevant", "Expected Behavior"]

--- a/src/config/env.rs
+++ b/src/config/env.rs
@@ -31,6 +31,9 @@ pub fn expand_vars(input: &str) -> String {
 /// Apply env expansion to key string fields in a ServiceConfig.
 pub fn expand_config(config: &mut ServiceConfig) {
     config.tracker.mcp_command = expand_vars(&config.tracker.mcp_command);
+    if let Some(ref s) = config.tracker.mcp_url {
+        config.tracker.mcp_url = Some(expand_vars(s));
+    }
     config.tracker.database_id = expand_vars(&config.tracker.database_id);
     config.workspace.root = expand_vars(&config.workspace.root);
     config.codex.command = expand_vars(&config.codex.command);

--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -21,6 +21,7 @@ pub struct ServiceConfig {
 pub struct TrackerConfig {
     pub kind: String,
     pub mcp_command: String,
+    pub mcp_url: Option<String>,
     pub database_id: String,
     pub active_states: Vec<String>,
     pub terminal_states: Vec<String>,
@@ -36,6 +37,7 @@ impl Default for TrackerConfig {
         Self {
             kind: "notion".to_string(),
             mcp_command: "npx -y @notionhq/notion-mcp-server".to_string(),
+            mcp_url: None,
             database_id: String::new(),
             active_states: vec!["Todo".to_string(), "In Progress".to_string()],
             terminal_states: vec!["Done".to_string(), "Cancelled".to_string()],

--- a/src/main.rs
+++ b/src/main.rs
@@ -23,20 +23,22 @@ async fn main() -> anyhow::Result<()> {
 
     symposium::logging::init(cli.json_logs);
 
+    // Canonicalize workflow path so the file watcher can resolve it
+    let workflow_path = std::fs::canonicalize(&cli.workflow_path)?;
+
     // Parse config
-    let config = symposium::config::workflow::parse_workflow_file(&cli.workflow_path)?;
-    tracing::info!("loaded config from {}", cli.workflow_path.display());
+    let config = symposium::config::workflow::parse_workflow_file(&workflow_path)?;
+    tracing::info!("loaded config from {}", workflow_path.display());
 
     // CLI --port overrides config; config overrides default 8080
     let port = cli.port.unwrap_or(config.server.port);
-    tracing::info!(workflow = %cli.workflow_path.display(), port, "starting symposium");
+    tracing::info!(workflow = %workflow_path.display(), port, "starting symposium");
 
     // Create config watch channel
     let (config_tx, config_rx) = tokio::sync::watch::channel(config);
 
     // Start config file watcher
-    let watch_path = cli.workflow_path.clone();
-    let _watcher = symposium::config::watch::spawn_watcher(watch_path, config_tx)?;
+    let _watcher = symposium::config::watch::spawn_watcher(workflow_path, config_tx)?;
 
     // Build shared orchestrator state
     let state = symposium::domain::state::OrchestratorState::new(config_rx.clone());

--- a/src/tracker/mcp_http.rs
+++ b/src/tracker/mcp_http.rs
@@ -1,0 +1,197 @@
+use super::oauth::OAuthClient;
+use crate::error::{Error, Result};
+use serde_json::Value;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+/// MCP client that communicates via Streamable HTTP transport.
+pub struct HttpMcpClient {
+    url: String,
+    http: reqwest::Client,
+    oauth: OAuthClient,
+    next_id: AtomicU64,
+    session_id: Option<String>,
+}
+
+impl HttpMcpClient {
+    pub async fn new(url: &str) -> Result<Self> {
+        let oauth = OAuthClient::new(url);
+        let mut client = Self {
+            url: url.trim_end_matches('/').to_string(),
+            http: reqwest::Client::new(),
+            oauth,
+            next_id: AtomicU64::new(1),
+            session_id: None,
+        };
+
+        client.initialize().await?;
+        Ok(client)
+    }
+
+    async fn initialize(&mut self) -> Result<()> {
+        let _result = self
+            .send_request(
+                "initialize",
+                serde_json::json!({
+                    "protocolVersion": "2025-03-26",
+                    "capabilities": {},
+                    "clientInfo": {
+                        "name": "symposium",
+                        "version": env!("CARGO_PKG_VERSION")
+                    }
+                }),
+            )
+            .await?;
+
+        self.send_notification("notifications/initialized", serde_json::json!({}))
+            .await?;
+
+        Ok(())
+    }
+
+    /// Call a tool on the MCP server.
+    pub async fn call_tool(&mut self, name: &str, args: Value) -> Result<Value> {
+        self.send_request(
+            "tools/call",
+            serde_json::json!({
+                "name": name,
+                "arguments": args
+            }),
+        )
+        .await
+    }
+
+    async fn send_request(&mut self, method: &str, params: Value) -> Result<Value> {
+        let id = self.next_id.fetch_add(1, Ordering::Relaxed);
+        let body = serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": id,
+            "method": method,
+            "params": params
+        });
+
+        let response = self.post_json(&body).await?;
+
+        // Extract Mcp-Session-Id from response headers
+        if let Some(sid) = response.headers().get("mcp-session-id")
+            && let Ok(s) = sid.to_str()
+        {
+            self.session_id = Some(s.to_string());
+        }
+
+        let status = response.status();
+        if status == reqwest::StatusCode::UNAUTHORIZED {
+            // Token might be stale — force re-auth and retry once
+            tracing::info!("MCP returned 401, re-authenticating...");
+            self.oauth = OAuthClient::new(&self.url);
+            let response = self.post_json(&body).await?;
+            return self.parse_response(response, id).await;
+        }
+
+        self.parse_response(response, id).await
+    }
+
+    async fn send_notification(&mut self, method: &str, params: Value) -> Result<()> {
+        let body = serde_json::json!({
+            "jsonrpc": "2.0",
+            "method": method,
+            "params": params
+        });
+        let _ = self.post_json(&body).await?;
+        Ok(())
+    }
+
+    async fn post_json(&mut self, body: &Value) -> Result<reqwest::Response> {
+        let token = self.oauth.get_token().await?;
+
+        let mut req = self
+            .http
+            .post(&self.url)
+            .header("Content-Type", "application/json")
+            .header("Accept", "application/json, text/event-stream")
+            .bearer_auth(&token);
+
+        if let Some(ref sid) = self.session_id {
+            req = req.header("Mcp-Session-Id", sid);
+        }
+
+        req.json(body)
+            .send()
+            .await
+            .map_err(|e| Error::Mcp(format!("HTTP request failed: {e}")))
+    }
+
+    async fn parse_response(&self, response: reqwest::Response, id: u64) -> Result<Value> {
+        let status = response.status();
+        if !status.is_success() {
+            let body = response.text().await.unwrap_or_default();
+            return Err(Error::Mcp(format!("MCP HTTP error {status}: {body}")));
+        }
+
+        let content_type = response
+            .headers()
+            .get("content-type")
+            .and_then(|v| v.to_str().ok())
+            .unwrap_or("")
+            .to_string();
+
+        let text = response
+            .text()
+            .await
+            .map_err(|e| Error::Mcp(format!("read response body: {e}")))?;
+
+        if content_type.contains("text/event-stream") {
+            self.parse_sse_response(&text, id)
+        } else {
+            self.parse_json_response(&text, id)
+        }
+    }
+
+    /// Parse a plain JSON or newline-delimited JSON response.
+    fn parse_json_response(&self, text: &str, id: u64) -> Result<Value> {
+        for line in text.lines() {
+            let trimmed = line.trim();
+            if trimmed.is_empty() {
+                continue;
+            }
+            if let Ok(msg) = serde_json::from_str::<Value>(trimmed)
+                && msg.get("id").and_then(|v| v.as_u64()) == Some(id) {
+                    if let Some(error) = msg.get("error") {
+                        return Err(Error::Mcp(format!("MCP error: {error}")));
+                    }
+                    return Ok(msg.get("result").cloned().unwrap_or(Value::Null));
+                }
+        }
+        Err(Error::Mcp("no matching response from MCP server".into()))
+    }
+
+    /// Parse a Server-Sent Events (SSE) response.
+    /// SSE format: lines starting with "data:" contain JSON-RPC messages.
+    fn parse_sse_response(&self, text: &str, id: u64) -> Result<Value> {
+        for line in text.lines() {
+            let trimmed = line.trim();
+
+            // SSE data lines start with "data:"
+            let json_str = if let Some(data) = trimmed.strip_prefix("data:") {
+                data.trim()
+            } else if trimmed.starts_with('{') {
+                // Some servers send raw JSON between SSE events
+                trimmed
+            } else {
+                continue;
+            };
+
+            if json_str.is_empty() {
+                continue;
+            }
+
+            if let Ok(msg) = serde_json::from_str::<Value>(json_str)
+                && msg.get("id").and_then(|v| v.as_u64()) == Some(id) {
+                    if let Some(error) = msg.get("error") {
+                        return Err(Error::Mcp(format!("MCP error: {error}")));
+                    }
+                    return Ok(msg.get("result").cloned().unwrap_or(Value::Null));
+                }
+        }
+        Err(Error::Mcp("no matching response in SSE stream".into()))
+    }
+}

--- a/src/tracker/mod.rs
+++ b/src/tracker/mod.rs
@@ -1,5 +1,7 @@
 pub mod mcp;
+pub mod mcp_http;
 pub mod notion;
+pub mod oauth;
 
 use crate::domain::issue::Issue;
 use crate::error::Result;

--- a/src/tracker/notion.rs
+++ b/src/tracker/notion.rs
@@ -1,4 +1,5 @@
 use super::mcp::McpClient;
+use super::mcp_http::HttpMcpClient;
 use super::TrackerClient;
 use crate::config::schema::TrackerConfig;
 use crate::domain::issue::Issue;
@@ -6,19 +7,39 @@ use crate::error::{Error, Result};
 use serde_json::Value;
 use std::collections::{HashMap, HashSet};
 
+/// Wraps either a stdio or HTTP MCP client.
+enum McpTransport {
+    Stdio(McpClient),
+    Http(HttpMcpClient),
+}
+
+impl McpTransport {
+    async fn call_tool(&mut self, name: &str, args: Value) -> Result<Value> {
+        match self {
+            Self::Stdio(c) => c.call_tool(name, args).await,
+            Self::Http(c) => c.call_tool(name, args).await,
+        }
+    }
+}
+
 pub struct NotionTracker {
-    client: McpClient,
+    client: McpTransport,
     config: TrackerConfig,
     data_source_id: Option<String>,
 }
 
 impl NotionTracker {
     pub async fn new(config: TrackerConfig) -> Result<Self> {
-        let parts: Vec<&str> = config.mcp_command.split_whitespace().collect();
-        let (cmd, args) = parts
-            .split_first()
-            .ok_or_else(|| Error::Tracker("empty mcp_command".into()))?;
-        let client = McpClient::new(cmd, args).await?;
+        let client = if let Some(ref url) = config.mcp_url {
+            tracing::info!(url, "connecting to MCP via HTTP");
+            McpTransport::Http(HttpMcpClient::new(url).await?)
+        } else {
+            let parts: Vec<&str> = config.mcp_command.split_whitespace().collect();
+            let (cmd, args) = parts
+                .split_first()
+                .ok_or_else(|| Error::Tracker("empty mcp_command".into()))?;
+            McpTransport::Stdio(McpClient::new(cmd, args).await?)
+        };
         Ok(Self {
             client,
             config,
@@ -26,19 +47,14 @@ impl NotionTracker {
         })
     }
 
-    /// Discover the data source ID for the configured database.
-    async fn ensure_data_source(&mut self) -> Result<String> {
+    /// Get the data source URL for the configured database.
+    fn data_source_url(&mut self) -> String {
         if let Some(ref id) = self.data_source_id {
-            return Ok(id.clone());
+            return id.clone();
         }
-        // Query data sources to find our database
-        let _result = self
-            .client
-            .call_tool("notion-query-data-sources", serde_json::json!({"query": ""}))
-            .await?;
         let ds_id = format!("collection://{}", self.config.database_id);
         self.data_source_id = Some(ds_id.clone());
-        Ok(ds_id)
+        ds_id
     }
 
     /// Build SQL query for fetching issues with given statuses.
@@ -54,16 +70,34 @@ impl NotionTracker {
         )
     }
 
+    /// Unwrap the MCP tool response to get the inner data.
+    /// MCP tools return `{"content": [{"type":"text","text":"{...}"}]}`.
+    fn unwrap_tool_result(result: &Value) -> Value {
+        // Try to extract text from MCP content blocks
+        if let Some(content) = result.get("content").and_then(|v| v.as_array()) {
+            for block in content {
+                if let Some(text) = block.get("text").and_then(|v| v.as_str())
+                    && let Ok(parsed) = serde_json::from_str::<Value>(text)
+                {
+                    return parsed;
+                }
+            }
+        }
+        // Already unwrapped or direct format
+        result.clone()
+    }
+
     /// Extract Issue structs from a Notion query result.
     fn extract_issues(&self, result: &Value) -> Vec<Issue> {
+        let data = Self::unwrap_tool_result(result);
         let mut issues = Vec::new();
 
-        let rows = result
+        let rows = data
             .get("results")
-            .or_else(|| result.get("content"))
             .and_then(|v| v.as_array());
 
         let Some(rows) = rows else {
+            tracing::debug!(response = %data, "no results array in response");
             return issues;
         };
 
@@ -72,6 +106,8 @@ impl NotionTracker {
                 issues.push(issue);
             }
         }
+
+        tracing::info!(count = issues.len(), "fetched issues from Notion");
         issues
     }
 
@@ -191,13 +227,18 @@ impl NotionTracker {
 
 impl TrackerClient for NotionTracker {
     async fn fetch_candidate_issues(&mut self) -> Result<Vec<Issue>> {
-        let ds_id = self.ensure_data_source().await?;
-        let sql = self.build_status_query(&ds_id, &self.config.active_states);
+        let ds_url = self.data_source_url();
+        let sql = self.build_status_query(&ds_url, &self.config.active_states);
         let result = self
             .client
             .call_tool(
                 "notion-query-data-sources",
-                serde_json::json!({"query": sql}),
+                serde_json::json!({
+                    "data": {
+                        "data_source_urls": [&ds_url],
+                        "query": sql
+                    }
+                }),
             )
             .await?;
         Ok(self.extract_issues(&result))
@@ -225,23 +266,34 @@ impl TrackerClient for NotionTracker {
     }
 
     async fn fetch_terminal_issues(&mut self) -> Result<Vec<Issue>> {
-        let ds_id = self.ensure_data_source().await?;
-        let sql = self.build_status_query(&ds_id, &self.config.terminal_states);
+        let ds_url = self.data_source_url();
+        let sql = self.build_status_query(&ds_url, &self.config.terminal_states);
         let result = self
             .client
             .call_tool(
                 "notion-query-data-sources",
-                serde_json::json!({"query": sql}),
+                serde_json::json!({
+                    "data": {
+                        "data_source_urls": [&ds_url],
+                        "query": sql
+                    }
+                }),
             )
             .await?;
         Ok(self.extract_issues(&result))
     }
 
     async fn agent_query(&mut self, sql: &str) -> Result<Value> {
+        let ds_url = self.data_source_url();
         self.client
             .call_tool(
                 "notion-query-data-sources",
-                serde_json::json!({"query": sql}),
+                serde_json::json!({
+                    "data": {
+                        "data_source_urls": [&ds_url],
+                        "query": sql
+                    }
+                }),
             )
             .await
     }

--- a/src/tracker/oauth.rs
+++ b/src/tracker/oauth.rs
@@ -1,0 +1,470 @@
+use crate::error::{Error, Result};
+use base64::{Engine, engine::general_purpose::URL_SAFE_NO_PAD};
+use rand::Rng;
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use std::path::PathBuf;
+use tokio::io::AsyncWriteExt;
+
+/// OAuth 2.0 token set, cached to disk.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TokenSet {
+    pub access_token: String,
+    pub refresh_token: Option<String>,
+    pub expires_at: u64,
+}
+
+impl TokenSet {
+    pub fn is_expired(&self) -> bool {
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs();
+        // Refresh 60s before expiry
+        now + 60 >= self.expires_at
+    }
+}
+
+/// OAuth server metadata from `.well-known/oauth-authorization-server`.
+#[derive(Debug, Deserialize)]
+struct OAuthMetadata {
+    authorization_endpoint: String,
+    token_endpoint: String,
+    registration_endpoint: Option<String>,
+}
+
+/// Dynamic client registration response.
+#[derive(Debug, Serialize, Deserialize)]
+struct ClientRegistration {
+    client_id: String,
+    client_secret: Option<String>,
+}
+
+/// Cached OAuth state (client registration + tokens).
+#[derive(Debug, Serialize, Deserialize)]
+struct OAuthCache {
+    server_url: String,
+    client: ClientRegistration,
+    tokens: Option<TokenSet>,
+}
+
+/// Manages OAuth 2.0 authorization code flow with PKCE for an MCP server.
+pub struct OAuthClient {
+    server_url: String,
+    http: reqwest::Client,
+    cache_path: PathBuf,
+    cache: Option<OAuthCache>,
+}
+
+impl OAuthClient {
+    pub fn new(server_url: &str) -> Self {
+        let cache_dir = dirs::data_local_dir()
+            .unwrap_or_else(|| PathBuf::from("~/.local/share"))
+            .join("symposium")
+            .join("oauth");
+
+        // Derive cache filename from server URL
+        let hash = {
+            let mut h = Sha256::new();
+            h.update(server_url.as_bytes());
+            URL_SAFE_NO_PAD.encode(h.finalize())[..16].to_string()
+        };
+        let cache_path = cache_dir.join(format!("{hash}.json"));
+
+        Self {
+            server_url: server_url.trim_end_matches('/').to_string(),
+            http: reqwest::Client::new(),
+            cache_path,
+            cache: None,
+        }
+    }
+
+    /// Get a valid access token, refreshing or re-authorizing as needed.
+    pub async fn get_token(&mut self) -> Result<String> {
+        // Load cache from disk if we haven't yet
+        if self.cache.is_none() {
+            self.cache = self.load_cache().await;
+        }
+
+        // If we have a non-expired token, use it
+        if let Some(ref cache) = self.cache
+            && let Some(ref tokens) = cache.tokens
+        {
+            if !tokens.is_expired() {
+                return Ok(tokens.access_token.clone());
+            }
+            // Try refresh
+            if let Some(ref refresh) = tokens.refresh_token {
+                match self.refresh_token(&cache.client, refresh).await {
+                    Ok(new_tokens) => {
+                        let access = new_tokens.access_token.clone();
+                        self.cache.as_mut().unwrap().tokens = Some(new_tokens);
+                        self.save_cache().await?;
+                        return Ok(access);
+                    }
+                    Err(e) => {
+                        tracing::warn!("token refresh failed, re-authorizing: {e}");
+                    }
+                }
+            }
+        }
+
+        // Full authorization flow
+        let metadata = self.fetch_metadata().await?;
+        let client = self.ensure_client(&metadata).await?;
+        let tokens = self.authorize(&metadata, &client).await?;
+        let access = tokens.access_token.clone();
+
+        self.cache = Some(OAuthCache {
+            server_url: self.server_url.clone(),
+            client,
+            tokens: Some(tokens),
+        });
+        self.save_cache().await?;
+
+        Ok(access)
+    }
+
+    /// Derive the OAuth base URL (scheme + host) from the MCP server URL,
+    /// stripping the path per the MCP OAuth discovery spec.
+    fn oauth_base_url(&self) -> String {
+        // Find the end of "scheme://host[:port]"
+        if let Some(rest) = self.server_url.strip_prefix("https://") {
+            let host_end = rest.find('/').unwrap_or(rest.len());
+            format!("https://{}", &rest[..host_end])
+        } else if let Some(rest) = self.server_url.strip_prefix("http://") {
+            let host_end = rest.find('/').unwrap_or(rest.len());
+            format!("http://{}", &rest[..host_end])
+        } else {
+            self.server_url.clone()
+        }
+    }
+
+    async fn fetch_metadata(&self) -> Result<OAuthMetadata> {
+        let base = self.oauth_base_url();
+        let url = format!("{base}/.well-known/oauth-authorization-server");
+        self.http
+            .get(&url)
+            .send()
+            .await
+            .map_err(|e| Error::Mcp(format!("OAuth discovery failed: {e}")))?
+            .json::<OAuthMetadata>()
+            .await
+            .map_err(|e| Error::Mcp(format!("OAuth discovery parse failed: {e}")))
+    }
+
+    async fn ensure_client(&mut self, metadata: &OAuthMetadata) -> Result<ClientRegistration> {
+        // Reuse cached client registration if available for this server
+        if let Some(ref cache) = self.cache
+            && cache.server_url == self.server_url
+        {
+            return Ok(ClientRegistration {
+                client_id: cache.client.client_id.clone(),
+                client_secret: cache.client.client_secret.clone(),
+            });
+        }
+
+        let reg_url = metadata.registration_endpoint.as_ref().ok_or_else(|| {
+            Error::Mcp("MCP server does not support dynamic client registration".into())
+        })?;
+
+        let resp = self
+            .http
+            .post(reg_url)
+            .json(&serde_json::json!({
+                "client_name": "symposium",
+                "redirect_uris": ["http://127.0.0.1:19823/callback"],
+                "grant_types": ["authorization_code", "refresh_token"],
+                "response_types": ["code"],
+                "token_endpoint_auth_method": "none"
+            }))
+            .send()
+            .await
+            .map_err(|e| Error::Mcp(format!("client registration failed: {e}")))?;
+
+        if !resp.status().is_success() {
+            let body = resp.text().await.unwrap_or_default();
+            return Err(Error::Mcp(format!("client registration rejected: {body}")));
+        }
+
+        resp.json::<ClientRegistration>()
+            .await
+            .map_err(|e| Error::Mcp(format!("client registration parse failed: {e}")))
+    }
+
+    async fn authorize(
+        &self,
+        metadata: &OAuthMetadata,
+        client: &ClientRegistration,
+    ) -> Result<TokenSet> {
+        // Generate PKCE challenge
+        let verifier = generate_pkce_verifier();
+        let challenge = generate_pkce_challenge(&verifier);
+
+        // Generate state parameter
+        let state = generate_random_string(32);
+
+        // Start local callback server
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:19823")
+            .await
+            .map_err(|e| Error::Mcp(format!("failed to bind callback server: {e}")))?;
+
+        // Build authorization URL
+        let auth_url = format!(
+            "{}?response_type=code&client_id={}&redirect_uri={}&state={}&code_challenge={}&code_challenge_method=S256",
+            metadata.authorization_endpoint,
+            urlencoded(&client.client_id),
+            urlencoded("http://127.0.0.1:19823/callback"),
+            urlencoded(&state),
+            urlencoded(&challenge),
+        );
+
+        tracing::info!("opening browser for OAuth authorization...");
+        eprintln!("\n  Authorize Symposium at:\n  {auth_url}\n");
+        let _ = open::that(&auth_url);
+
+        // Wait for callback
+        let code = wait_for_callback(listener, &state).await?;
+
+        // Exchange code for tokens
+        self.exchange_code(metadata, client, &code, &verifier)
+            .await
+    }
+
+    async fn exchange_code(
+        &self,
+        metadata: &OAuthMetadata,
+        client: &ClientRegistration,
+        code: &str,
+        verifier: &str,
+    ) -> Result<TokenSet> {
+        let mut params = vec![
+            ("grant_type", "authorization_code"),
+            ("code", code),
+            ("redirect_uri", "http://127.0.0.1:19823/callback"),
+            ("client_id", &client.client_id),
+            ("code_verifier", verifier),
+        ];
+        let secret_str;
+        if let Some(ref secret) = client.client_secret {
+            secret_str = secret.clone();
+            params.push(("client_secret", &secret_str));
+        }
+
+        let resp = self
+            .http
+            .post(&metadata.token_endpoint)
+            .form(&params)
+            .send()
+            .await
+            .map_err(|e| Error::Mcp(format!("token exchange failed: {e}")))?;
+
+        if !resp.status().is_success() {
+            let body = resp.text().await.unwrap_or_default();
+            return Err(Error::Mcp(format!("token exchange rejected: {body}")));
+        }
+
+        parse_token_response(resp).await
+    }
+
+    async fn refresh_token(
+        &self,
+        client: &ClientRegistration,
+        refresh_token: &str,
+    ) -> Result<TokenSet> {
+        let metadata = self.fetch_metadata().await?;
+
+        let mut params = vec![
+            ("grant_type", "refresh_token"),
+            ("refresh_token", refresh_token),
+            ("client_id", &client.client_id),
+        ];
+        let secret_str;
+        if let Some(ref secret) = client.client_secret {
+            secret_str = secret.clone();
+            params.push(("client_secret", &secret_str));
+        }
+
+        let resp = self
+            .http
+            .post(&metadata.token_endpoint)
+            .form(&params)
+            .send()
+            .await
+            .map_err(|e| Error::Mcp(format!("token refresh failed: {e}")))?;
+
+        if !resp.status().is_success() {
+            let body = resp.text().await.unwrap_or_default();
+            return Err(Error::Mcp(format!("token refresh rejected: {body}")));
+        }
+
+        parse_token_response(resp).await
+    }
+
+    async fn load_cache(&self) -> Option<OAuthCache> {
+        let data = tokio::fs::read_to_string(&self.cache_path).await.ok()?;
+        serde_json::from_str(&data).ok()
+    }
+
+    async fn save_cache(&self) -> Result<()> {
+        let Some(ref cache) = self.cache else {
+            return Ok(());
+        };
+        if let Some(parent) = self.cache_path.parent() {
+            tokio::fs::create_dir_all(parent).await.map_err(|e| {
+                Error::Mcp(format!("failed to create oauth cache dir: {e}"))
+            })?;
+        }
+        let data = serde_json::to_string_pretty(cache)
+            .map_err(|e| Error::Mcp(format!("serialize cache: {e}")))?;
+        let mut file = tokio::fs::File::create(&self.cache_path)
+            .await
+            .map_err(|e| Error::Mcp(format!("create cache file: {e}")))?;
+        file.write_all(data.as_bytes())
+            .await
+            .map_err(|e| Error::Mcp(format!("write cache file: {e}")))?;
+        Ok(())
+    }
+}
+
+async fn parse_token_response(resp: reqwest::Response) -> Result<TokenSet> {
+    #[derive(Deserialize)]
+    struct TokenResponse {
+        access_token: String,
+        refresh_token: Option<String>,
+        expires_in: Option<u64>,
+    }
+
+    let tr: TokenResponse = resp
+        .json()
+        .await
+        .map_err(|e| Error::Mcp(format!("token response parse failed: {e}")))?;
+
+    let expires_at = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs()
+        + tr.expires_in.unwrap_or(3600);
+
+    Ok(TokenSet {
+        access_token: tr.access_token,
+        refresh_token: tr.refresh_token,
+        expires_at,
+    })
+}
+
+/// Wait for the OAuth callback on the local listener, extract the authorization code.
+async fn wait_for_callback(
+    listener: tokio::net::TcpListener,
+    expected_state: &str,
+) -> Result<String> {
+    use tokio::io::AsyncReadExt;
+
+    let timeout = tokio::time::Duration::from_secs(120);
+    let (mut stream, _) = tokio::time::timeout(timeout, listener.accept())
+        .await
+        .map_err(|_| Error::Mcp("OAuth callback timed out after 120s".into()))?
+        .map_err(|e| Error::Mcp(format!("callback accept error: {e}")))?;
+
+    let mut buf = vec![0u8; 4096];
+    let n = stream
+        .read(&mut buf)
+        .await
+        .map_err(|e| Error::Mcp(format!("callback read error: {e}")))?;
+    let request = String::from_utf8_lossy(&buf[..n]);
+
+    // Parse the GET request line to extract query params
+    let path = request
+        .lines()
+        .next()
+        .and_then(|line| line.split_whitespace().nth(1))
+        .ok_or_else(|| Error::Mcp("malformed callback request".into()))?;
+
+    let query = path
+        .split('?')
+        .nth(1)
+        .ok_or_else(|| Error::Mcp("no query params in callback".into()))?;
+
+    let mut code = None;
+    let mut state = None;
+    let mut error = None;
+    for pair in query.split('&') {
+        let mut kv = pair.splitn(2, '=');
+        match (kv.next(), kv.next()) {
+            (Some("code"), Some(v)) => code = Some(urldecoded(v)),
+            (Some("state"), Some(v)) => state = Some(urldecoded(v)),
+            (Some("error"), Some(v)) => error = Some(urldecoded(v)),
+            _ => {}
+        }
+    }
+
+    if let Some(err) = error {
+        // Send error response
+        let response = format!(
+            "HTTP/1.1 200 OK\r\nContent-Type: text/html\r\nConnection: close\r\n\r\n\
+             <html><body><h2>Authorization failed: {err}</h2><p>You can close this tab.</p></body></html>"
+        );
+        let _ = stream.write_all(response.as_bytes()).await;
+        return Err(Error::Mcp(format!("OAuth authorization denied: {err}")));
+    }
+
+    let code = code.ok_or_else(|| Error::Mcp("no code in callback".into()))?;
+    let state = state.ok_or_else(|| Error::Mcp("no state in callback".into()))?;
+
+    if state != expected_state {
+        return Err(Error::Mcp("OAuth state mismatch".into()));
+    }
+
+    // Send success response
+    let response = "HTTP/1.1 200 OK\r\nContent-Type: text/html\r\nConnection: close\r\n\r\n\
+         <html><body><h2>Symposium authorized!</h2><p>You can close this tab.</p></body></html>";
+    let _ = stream.write_all(response.as_bytes()).await;
+
+    Ok(code)
+}
+
+fn generate_random_string(len: usize) -> String {
+    let bytes: Vec<u8> = (0..len).map(|_| rand::rng().random::<u8>()).collect();
+    URL_SAFE_NO_PAD.encode(&bytes)
+}
+
+fn generate_pkce_verifier() -> String {
+    generate_random_string(32)
+}
+
+fn generate_pkce_challenge(verifier: &str) -> String {
+    let digest = Sha256::digest(verifier.as_bytes());
+    URL_SAFE_NO_PAD.encode(digest)
+}
+
+fn urlencoded(s: &str) -> String {
+    s.chars()
+        .flat_map(|c| match c {
+            'A'..='Z' | 'a'..='z' | '0'..='9' | '-' | '_' | '.' | '~' => {
+                vec![c]
+            }
+            _ => format!("%{:02X}", c as u8).chars().collect(),
+        })
+        .collect()
+}
+
+fn urldecoded(s: &str) -> String {
+    let mut result = String::with_capacity(s.len());
+    let mut chars = s.chars();
+    while let Some(c) = chars.next() {
+        if c == '%' {
+            let hex: String = chars.by_ref().take(2).collect();
+            if let Ok(byte) = u8::from_str_radix(&hex, 16) {
+                result.push(byte as char);
+            } else {
+                result.push('%');
+                result.push_str(&hex);
+            }
+        } else if c == '+' {
+            result.push(' ');
+        } else {
+            result.push(c);
+        }
+    }
+    result
+}


### PR DESCRIPTION
## Summary
- Add Streamable HTTP MCP transport as alternative to stdio subprocess
- Implement OAuth 2.0 authorization code flow with PKCE for `mcp-dev.notion.com`
- Dynamic client registration, browser-based auth, cached refresh tokens
- SSE response parsing for MCP Streamable HTTP protocol
- Fix workflow path canonicalization, tool argument wrapping, content block unwrapping

## Test plan
- [x] `cargo test` — 18 tests pass
- [x] `cargo clippy` — clean
- [x] End-to-end: Symposium authenticates with mcp-dev.notion.com, fetches 100 bugs, dispatches 3 workers