### PR TITLE
Rewrite agent runtime and add post-completion review pipeline

### DIFF
--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -17,21 +17,23 @@ impl AgentRunner {
     }
 
     /// Start a new agent session in the given workspace directory.
+    /// Spawns `claude -p --output-format stream-json --verbose` with the prompt on stdin.
     pub async fn start_session(
         &self,
         workspace_dir: &Path,
         prompt: &str,
         issue_id: &str,
     ) -> Result<worker::AgentWorker> {
-        let proc = process::AgentProcess::spawn(
-            &self.config.codex.command,
-            workspace_dir,
-        )
-        .await?;
+        let cmd = format!(
+            "{} -p --output-format stream-json --verbose --no-session-persistence --dangerously-skip-permissions",
+            self.config.codex.command
+        );
 
-        let mut w = worker::AgentWorker::new(proc, issue_id.to_string());
-        w.initialize(&self.config).await?;
-        w.start_thread(prompt).await?;
-        Ok(w)
+        let mut proc = process::AgentProcess::spawn(&cmd, workspace_dir).await?;
+
+        // Write prompt to stdin and close it — claude -p reads until EOF
+        proc.write_and_close_stdin(prompt).await?;
+
+        Ok(worker::AgentWorker::new(proc, issue_id.to_string()))
     }
 }

--- a/src/agent/process.rs
+++ b/src/agent/process.rs
@@ -2,28 +2,31 @@ use crate::error::{Error, Result};
 use serde_json::Value;
 use std::path::Path;
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader, BufWriter};
-use tokio::process::{Child, ChildStdin, ChildStdout, Command};
+use tokio::process::{Child, ChildStdin, ChildStdout};
 
 pub struct AgentProcess {
     child: Child,
-    writer: BufWriter<ChildStdin>,
+    writer: Option<BufWriter<ChildStdin>>,
     reader: BufReader<ChildStdout>,
 }
 
 impl AgentProcess {
-    /// Spawn the agent subprocess.
+    /// Spawn claude in streaming JSON mode for multi-turn conversation.
     pub async fn spawn(command: &str, cwd: &Path) -> Result<Self> {
         let parts: Vec<&str> = command.split_whitespace().collect();
         let (program, args) = parts
             .split_first()
             .ok_or_else(|| Error::Agent("empty agent command".into()))?;
 
-        let mut child = Command::new(program)
-            .args(args)
+        let mut cmd = tokio::process::Command::new(program);
+        cmd.args(args)
             .current_dir(cwd)
+            .env_remove("CLAUDECODE")
             .stdin(std::process::Stdio::piped())
             .stdout(std::process::Stdio::piped())
-            .stderr(std::process::Stdio::inherit())
+            .stderr(std::process::Stdio::piped());
+
+        let mut child = cmd
             .spawn()
             .map_err(|e| Error::Agent(format!("failed to spawn agent: {e}")))?;
 
@@ -38,41 +41,60 @@ impl AgentProcess {
 
         Ok(Self {
             child,
-            writer: BufWriter::new(stdin),
+            writer: Some(BufWriter::new(stdin)),
             reader: BufReader::new(stdout),
         })
     }
 
-    /// Send a JSON message (line-delimited).
-    pub async fn send(&mut self, msg: &Value) -> Result<()> {
-        let mut line = serde_json::to_string(msg)
-            .map_err(|e| Error::AgentProtocol(format!("serialize error: {e}")))?;
-        line.push('\n');
-        self.writer
-            .write_all(line.as_bytes())
+    /// Write raw text to stdin and close it (drop the writer to close the pipe).
+    pub async fn write_and_close_stdin(&mut self, text: &str) -> Result<()> {
+        let writer = self
+            .writer
+            .as_mut()
+            .ok_or_else(|| Error::Agent("stdin already closed".into()))?;
+        writer
+            .write_all(text.as_bytes())
             .await
             .map_err(|e| Error::Agent(format!("write error: {e}")))?;
-        self.writer
+        writer
             .flush()
             .await
             .map_err(|e| Error::Agent(format!("flush error: {e}")))?;
+        // Drop the writer to close the pipe — this signals EOF to the child
+        self.writer = None;
         Ok(())
     }
 
     /// Read the next JSON message from stdout. Returns None if the process exited.
     pub async fn recv(&mut self) -> Result<Option<Value>> {
-        let mut line = String::new();
-        let n = self
-            .reader
-            .read_line(&mut line)
-            .await
-            .map_err(|e| Error::Agent(format!("read error: {e}")))?;
-        if n == 0 {
-            return Ok(None);
+        loop {
+            let mut line = String::new();
+            let n = self
+                .reader
+                .read_line(&mut line)
+                .await
+                .map_err(|e| Error::Agent(format!("read error: {e}")))?;
+            if n == 0 {
+                // Process closed stdout — try to capture stderr for diagnostics
+                if let Some(stderr) = self.child.stderr.as_mut() {
+                    let mut buf = String::new();
+                    let mut stderr_reader = tokio::io::BufReader::new(stderr);
+                    while stderr_reader.read_line(&mut buf).await.unwrap_or(0) > 0 {}
+                    if !buf.is_empty() {
+                        tracing::error!(stderr = %buf.trim(), "agent process stderr");
+                    }
+                }
+                return Ok(None);
+            }
+            let trimmed = line.trim();
+            if trimmed.is_empty() {
+                continue;
+            }
+            tracing::trace!(line = %trimmed, "agent stdout");
+            let value = serde_json::from_str(trimmed)
+                .map_err(|e| Error::AgentProtocol(format!("parse error on `{}`: {e}", &trimmed[..trimmed.len().min(100)])))?;
+            return Ok(Some(value));
         }
-        let value = serde_json::from_str(line.trim())
-            .map_err(|e| Error::AgentProtocol(format!("parse error on line: {e}")))?;
-        Ok(Some(value))
     }
 
     /// Kill the process.

--- a/src/agent/worker.rs
+++ b/src/agent/worker.rs
@@ -1,192 +1,26 @@
 use super::process::AgentProcess;
-use super::protocol::*;
-use super::tools;
 use crate::config::schema::ServiceConfig;
 use crate::error::{Error, Result};
-use serde_json::{json, Value};
 
 pub struct AgentWorker {
-    process: AgentProcess,
+    pub(crate) process: AgentProcess,
+    #[allow(dead_code)]
     issue_id: String,
-    thread_id: Option<String>,
-    turn_id: Option<String>,
-    next_id: u64,
 }
 
 impl AgentWorker {
     pub fn new(process: AgentProcess, issue_id: String) -> Self {
-        Self {
-            process,
-            issue_id,
-            thread_id: None,
-            turn_id: None,
-            next_id: 1,
-        }
+        Self { process, issue_id }
     }
 
-    fn next_request_id(&mut self) -> u64 {
-        let id = self.next_id;
-        self.next_id += 1;
-        id
-    }
-
-    /// Perform the initialize handshake.
+    /// No-op for stream-json mode — initialization happens at spawn.
     pub async fn initialize(&mut self, _config: &ServiceConfig) -> Result<()> {
-        let req = JsonRpcRequest::new(
-            self.next_request_id(),
-            "initialize",
-            Some(json!({
-                "protocolVersion": "2024-01-01",
-                "capabilities": {},
-                "clientInfo": {
-                    "name": "symposium",
-                    "version": env!("CARGO_PKG_VERSION")
-                }
-            })),
-        );
-        self.process
-            .send(&serde_json::to_value(&req).unwrap())
-            .await?;
-
-        let resp = self.read_response(req.id).await?;
-        tracing::debug!(issue_id = %self.issue_id, "agent initialized: {resp:?}");
-
-        let notif = JsonRpcNotification::new("initialized", Some(json!({})));
-        self.process
-            .send(&serde_json::to_value(&notif).unwrap())
-            .await?;
-
         Ok(())
     }
 
-    /// Start a new thread with the given prompt.
-    pub async fn start_thread(&mut self, prompt: &str) -> Result<()> {
-        let req = JsonRpcRequest::new(
-            self.next_request_id(),
-            "thread/start",
-            Some(json!({
-                "instructions": prompt
-            })),
-        );
-        self.process
-            .send(&serde_json::to_value(&req).unwrap())
-            .await?;
-
-        let resp = self.read_response(req.id).await?;
-        self.thread_id = resp
-            .get("threadId")
-            .and_then(|v| v.as_str())
-            .map(String::from);
-
-        tracing::info!(issue_id = %self.issue_id, thread_id = ?self.thread_id, "thread started");
+    /// No-op — the prompt is passed via stdin at spawn time.
+    pub async fn start_thread(&mut self, _prompt: &str) -> Result<()> {
         Ok(())
-    }
-
-    /// Run a single turn. Returns the turn result.
-    pub async fn run_turn(&mut self, prompt: &str) -> Result<TurnResult> {
-        let thread_id = self
-            .thread_id
-            .clone()
-            .ok_or_else(|| Error::AgentProtocol("no thread_id".into()))?;
-
-        let req = JsonRpcRequest::new(
-            self.next_request_id(),
-            "turn/start",
-            Some(json!({
-                "threadId": thread_id,
-                "message": prompt
-            })),
-        );
-        self.process
-            .send(&serde_json::to_value(&req).unwrap())
-            .await?;
-
-        loop {
-            let msg = match self.process.recv().await? {
-                Some(msg) => msg,
-                None => return Ok(TurnResult::AgentExited),
-            };
-
-            if let Some(id) = msg.get("id").and_then(|v| v.as_u64())
-                && id == req.id {
-                    self.turn_id = msg
-                        .get("result")
-                        .and_then(|r| r.get("turnId"))
-                        .and_then(|v| v.as_str())
-                        .map(String::from);
-                    continue;
-                }
-
-            if let Some(method) = msg.get("method").and_then(|v| v.as_str())
-                && method == "turn/event"
-                    && let Some(params) = msg.get("params") {
-                        match serde_json::from_value::<TurnEvent>(params.clone()) {
-                            Ok(TurnEvent::TurnComplete { .. }) => {
-                                return Ok(TurnResult::Complete);
-                            }
-                            Ok(TurnEvent::ToolCall {
-                                id,
-                                name,
-                                arguments,
-                            }) => {
-                                if tools::is_client_tool(&name) {
-                                    return Ok(TurnResult::NeedsToolResponse {
-                                        tool_call_id: id,
-                                        tool_name: name,
-                                        arguments,
-                                    });
-                                }
-                            }
-                            Ok(TurnEvent::Error { message }) => {
-                                return Ok(TurnResult::Error(message));
-                            }
-                            Ok(TurnEvent::TextDelta { delta }) => {
-                                tracing::trace!(issue_id = %self.issue_id, "text: {delta}");
-                            }
-                            Ok(_) => {}
-                            Err(e) => {
-                                tracing::warn!("failed to parse turn event: {e}");
-                            }
-                        }
-                    }
-        }
-    }
-
-    /// Send a tool response back to the agent.
-    pub async fn send_tool_response(&mut self, tool_call_id: &str, result: Value) -> Result<()> {
-        let req = JsonRpcRequest::new(
-            self.next_request_id(),
-            "turn/toolResponse",
-            Some(json!({
-                "toolCallId": tool_call_id,
-                "content": result
-            })),
-        );
-        self.process
-            .send(&serde_json::to_value(&req).unwrap())
-            .await?;
-        Ok(())
-    }
-
-    /// Read a JSON-RPC response with the given ID, skipping notifications.
-    async fn read_response(&mut self, expected_id: u64) -> Result<Value> {
-        loop {
-            let msg = self
-                .process
-                .recv()
-                .await?
-                .ok_or_else(|| {
-                    Error::AgentProtocol("agent process exited during handshake".into())
-                })?;
-
-            if let Some(id) = msg.get("id").and_then(|v| v.as_u64())
-                && id == expected_id {
-                    if let Some(error) = msg.get("error") {
-                        return Err(Error::AgentProtocol(format!("agent error: {error}")));
-                    }
-                    return Ok(msg.get("result").cloned().unwrap_or(Value::Null));
-                }
-        }
     }
 
     pub async fn kill(&mut self) -> Result<()> {
@@ -194,45 +28,160 @@ impl AgentWorker {
     }
 }
 
-/// Run a full agent attempt: multiple turns until completion or max_turns.
+/// Result of a streamed event from the agent.
+#[derive(Debug)]
+pub enum StreamEvent {
+    /// Agent sent a text message
+    AssistantText(String),
+    /// Agent is using a tool
+    ToolUse { name: String, input: String },
+    /// Agent finished successfully
+    Result { result: String, cost_usd: f64, num_turns: u64 },
+    /// Agent errored
+    Error(String),
+    /// Process exited
+    Eof,
+}
+
+/// Run the agent to completion, streaming events back to state.
 pub async fn run_agent_attempt(
     worker: &mut AgentWorker,
-    initial_prompt: &str,
-    max_turns: u32,
+    _initial_prompt: &str,
+    _max_turns: u32,
+    state: &crate::domain::state::OrchestratorState,
+    issue_id: &str,
 ) -> Result<bool> {
-    let mut turn = 0u32;
-    let mut prompt = initial_prompt.to_string();
+    use crate::domain::session::{AgentEvent, AgentEventKind};
 
     loop {
-        if turn >= max_turns {
-            tracing::warn!("max turns ({max_turns}) reached");
-            return Ok(false);
-        }
+        let msg = match worker.process.recv().await? {
+            Some(msg) => msg,
+            None => {
+                state.push_agent_event(
+                    issue_id,
+                    AgentEvent::now(AgentEventKind::Error {
+                        message: "agent process exited".into(),
+                    }),
+                );
+                return Err(Error::Agent("agent process exited unexpectedly".into()));
+            }
+        };
 
-        let result = worker.run_turn(&prompt).await?;
-        turn += 1;
+        let msg_type = msg.get("type").and_then(|v| v.as_str()).unwrap_or("");
 
-        match result {
-            TurnResult::Complete => {
-                tracing::info!(turn, "agent completed successfully");
+        match msg_type {
+            "system" => {
+                let subtype = msg.get("subtype").and_then(|v| v.as_str()).unwrap_or("");
+                if subtype == "init" {
+                    state.push_agent_event(
+                        issue_id,
+                        AgentEvent::now(AgentEventKind::Status {
+                            status: "Agent initialized".into(),
+                        }),
+                    );
+                    state.update_session_status(
+                        issue_id,
+                        crate::domain::session::RunStatus::Running,
+                    );
+                }
+            }
+            "assistant" => {
+                // Extract tool use or text from the message
+                if let Some(message) = msg.get("message")
+                    && let Some(content) = message.get("content").and_then(|v| v.as_array())
+                {
+                        for block in content {
+                            let block_type =
+                                block.get("type").and_then(|v| v.as_str()).unwrap_or("");
+                            match block_type {
+                                "text" => {
+                                    if let Some(text) = block.get("text").and_then(|v| v.as_str())
+                                    {
+                                        let preview: String = text.chars().take(300).collect();
+                                        state.push_agent_event(
+                                            issue_id,
+                                            AgentEvent::now(AgentEventKind::Text {
+                                                text: preview,
+                                            }),
+                                        );
+                                    }
+                                }
+                                "tool_use" => {
+                                    let name = block
+                                        .get("name")
+                                        .and_then(|v| v.as_str())
+                                        .unwrap_or("unknown");
+                                    let input = block
+                                        .get("input")
+                                        .map(|v| v.to_string())
+                                        .unwrap_or_default();
+                                    let truncated: String = input.chars().take(200).collect();
+                                    state.push_agent_event(
+                                        issue_id,
+                                        AgentEvent::now(AgentEventKind::ToolCall {
+                                            name: name.to_string(),
+                                            arguments: truncated,
+                                        }),
+                                    );
+                                    state.increment_turn(issue_id);
+                                }
+                                _ => {}
+                            }
+                        }
+                    }
+                }
+            "result" => {
+                let is_error = msg.get("is_error").and_then(|v| v.as_bool()).unwrap_or(false);
+                let result_text = msg
+                    .get("result")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("")
+                    .to_string();
+                let cost = msg
+                    .get("total_cost_usd")
+                    .and_then(|v| v.as_f64())
+                    .unwrap_or(0.0);
+                let num_turns = msg
+                    .get("num_turns")
+                    .and_then(|v| v.as_u64())
+                    .unwrap_or(0);
+
+                if is_error {
+                    state.push_agent_event(
+                        issue_id,
+                        AgentEvent::now(AgentEventKind::Error {
+                            message: result_text.clone(),
+                        }),
+                    );
+                    return Err(Error::Agent(result_text));
+                }
+
+                state.push_agent_event(
+                    issue_id,
+                    AgentEvent::now(AgentEventKind::TurnComplete {
+                        turn: num_turns as u32,
+                    }),
+                );
+                state.push_agent_event(
+                    issue_id,
+                    AgentEvent::now(AgentEventKind::Status {
+                        status: format!(
+                            "Completed in {num_turns} turns (${:.4})",
+                            cost
+                        ),
+                    }),
+                );
+
+                tracing::info!(
+                    issue_id,
+                    num_turns,
+                    cost_usd = cost,
+                    "agent completed"
+                );
                 return Ok(true);
             }
-            TurnResult::NeedsToolResponse {
-                tool_call_id,
-                tool_name,
-                arguments,
-            } => {
-                let tool_result = tools::handle_tool_call(&tool_name, &arguments).await?;
-                worker.send_tool_response(&tool_call_id, tool_result).await?;
-                prompt = "Continue with the tool result.".to_string();
-            }
-            TurnResult::Error(msg) => {
-                tracing::error!(turn, "agent error: {msg}");
-                return Err(Error::Agent(msg));
-            }
-            TurnResult::AgentExited => {
-                tracing::warn!(turn, "agent process exited unexpectedly");
-                return Err(Error::Agent("agent process exited".into()));
+            _ => {
+                // Skip unknown event types (hook events, etc.)
             }
         }
     }

--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -30,6 +30,9 @@ pub struct TrackerConfig {
     pub property_status: String,
     pub property_priority: String,
     pub property_description: String,
+    pub property_assignee: String,
+    /// Filter issues to only those assigned to this user ID.
+    pub assignee_user_id: Option<String>,
 }
 
 impl Default for TrackerConfig {
@@ -46,6 +49,8 @@ impl Default for TrackerConfig {
             property_status: "Status".to_string(),
             property_priority: "Priority".to_string(),
             property_description: "Description".to_string(),
+            property_assignee: "Assignee".to_string(),
+            assignee_user_id: None,
         }
     }
 }

--- a/src/domain/session.rs
+++ b/src/domain/session.rs
@@ -1,6 +1,8 @@
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
+const MAX_EVENTS: usize = 200;
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct LiveSession {
     pub issue_id: String,
@@ -10,6 +12,7 @@ pub struct LiveSession {
     pub started_at: DateTime<Utc>,
     pub last_activity: DateTime<Utc>,
     pub attempts: Vec<RunAttempt>,
+    pub events: Vec<AgentEvent>,
 }
 
 impl LiveSession {
@@ -23,6 +26,47 @@ impl LiveSession {
             started_at: now,
             last_activity: now,
             attempts: Vec::new(),
+            events: Vec::new(),
+        }
+    }
+
+    pub fn push_event(&mut self, event: AgentEvent) {
+        self.last_activity = Utc::now();
+        self.events.push(event);
+        if self.events.len() > MAX_EVENTS {
+            self.events.drain(..self.events.len() - MAX_EVENTS);
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AgentEvent {
+    pub timestamp: DateTime<Utc>,
+    pub kind: AgentEventKind,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "type")]
+pub enum AgentEventKind {
+    #[serde(rename = "status")]
+    Status { status: String },
+    #[serde(rename = "text")]
+    Text { text: String },
+    #[serde(rename = "tool_call")]
+    ToolCall { name: String, arguments: String },
+    #[serde(rename = "tool_result")]
+    ToolResult { name: String, truncated: String },
+    #[serde(rename = "turn_complete")]
+    TurnComplete { turn: u32 },
+    #[serde(rename = "error")]
+    Error { message: String },
+}
+
+impl AgentEvent {
+    pub fn now(kind: AgentEventKind) -> Self {
+        Self {
+            timestamp: Utc::now(),
+            kind,
         }
     }
 }

--- a/src/domain/state.rs
+++ b/src/domain/state.rs
@@ -78,6 +78,15 @@ impl OrchestratorState {
         self.inner.lock().unwrap().retries.contains_key(issue_id)
     }
 
+    pub fn is_completed_successfully(&self, issue_id: &str) -> bool {
+        self.inner
+            .lock()
+            .unwrap()
+            .completed
+            .iter()
+            .any(|e| e.issue_id == issue_id && e.success)
+    }
+
     pub fn running_count(&self) -> usize {
         self.inner.lock().unwrap().running.len()
     }
@@ -140,9 +149,33 @@ impl OrchestratorState {
             .collect()
     }
 
-    pub fn record_agent_event(&self, issue_id: &str, _event: serde_json::Value) {
+    pub fn push_agent_event(
+        &self,
+        issue_id: &str,
+        event: super::session::AgentEvent,
+    ) {
         let mut inner = self.inner.lock().unwrap();
         if let Some(entry) = inner.running.get_mut(issue_id) {
+            entry.session.push_event(event);
+        }
+    }
+
+    pub fn update_session_status(
+        &self,
+        issue_id: &str,
+        status: super::session::RunStatus,
+    ) {
+        let mut inner = self.inner.lock().unwrap();
+        if let Some(entry) = inner.running.get_mut(issue_id) {
+            entry.session.status = status;
+            entry.session.last_activity = Utc::now();
+        }
+    }
+
+    pub fn increment_turn(&self, issue_id: &str) {
+        let mut inner = self.inner.lock().unwrap();
+        if let Some(entry) = inner.running.get_mut(issue_id) {
+            entry.session.current_turn += 1;
             entry.session.last_activity = Utc::now();
         }
     }

--- a/src/orchestrator/dispatch.rs
+++ b/src/orchestrator/dispatch.rs
@@ -12,6 +12,10 @@ pub fn is_eligible(issue: &Issue, state: &OrchestratorState, config: &ServiceCon
     if state.is_in_retry(&issue.identifier) {
         return false;
     }
+    // Not already completed successfully
+    if state.is_completed_successfully(&issue.identifier) {
+        return false;
+    }
     // Under concurrency limit
     if state.running_count() >= config.agent.max_concurrent_agents {
         return false;

--- a/src/orchestrator/mod.rs
+++ b/src/orchestrator/mod.rs
@@ -98,7 +98,8 @@ impl Orchestrator {
             }
             OrchestratorEvent::AgentUpdate { issue_id, event } => {
                 tracing::debug!(issue_id, "agent update");
-                self.state.record_agent_event(&issue_id, event);
+                // Events are now pushed directly from workers via state.push_agent_event
+                let _ = (issue_id, event);
             }
             OrchestratorEvent::ConfigReloaded => {
                 tracing::info!("config reloaded event");

--- a/src/orchestrator/tick.rs
+++ b/src/orchestrator/tick.rs
@@ -99,8 +99,9 @@ fn dispatch_issue(
     let config_rx = config_rx.clone();
     let event_tx = event_tx.clone();
 
+    let state_clone = state.clone();
     tokio::spawn(async move {
-        let result = run_worker(&issue, &config, &config_rx, None).await;
+        let result = run_worker(&issue, &config, &config_rx, None, &state_clone).await;
 
         let (success, error) = match &result {
             Ok(true) => (true, None),
@@ -129,7 +130,7 @@ fn dispatch_issue(
 /// Spawn a worker task for a retry.
 fn dispatch_retry(
     retry: RetryEntry,
-    _state: &OrchestratorState,
+    state: &OrchestratorState,
     config: &ServiceConfig,
     config_rx: &watch::Receiver<ServiceConfig>,
     event_tx: &mpsc::Sender<OrchestratorEvent>,
@@ -143,6 +144,7 @@ fn dispatch_retry(
     let config = config.clone();
     let config_rx = config_rx.clone();
     let event_tx = event_tx.clone();
+    let state_clone = state.clone();
     let attempt = retry.attempt;
 
     tokio::spawn(async move {
@@ -168,7 +170,7 @@ fn dispatch_retry(
             return;
         };
 
-        let result = run_worker(&issue, &config, &config_rx, Some(attempt)).await;
+        let result = run_worker(&issue, &config, &config_rx, Some(attempt), &state_clone).await;
 
         let (success, error) = match &result {
             Ok(true) => (true, None),
@@ -200,10 +202,20 @@ async fn run_worker(
     config: &ServiceConfig,
     config_rx: &watch::Receiver<ServiceConfig>,
     attempt: Option<u32>,
+    state: &OrchestratorState,
 ) -> Result<bool> {
+    use crate::domain::session::{AgentEvent, AgentEventKind, RunStatus};
+    use crate::workspace::hooks;
+
     let ws = WorkspaceManager::new(config_rx.clone());
 
     // Ensure workspace exists (creates + runs after_create hook if new)
+    state.push_agent_event(
+        &issue.identifier,
+        AgentEvent::now(AgentEventKind::Status {
+            status: "Setting up workspace".into(),
+        }),
+    );
     let workspace_dir = ws.ensure(issue).await?;
 
     // Run before_run hook
@@ -213,19 +225,165 @@ async fn run_worker(
     let prompt_text = prompt::build_prompt(&config.prompt_template, issue, attempt)?;
 
     // Start agent session
+    state.push_agent_event(
+        &issue.identifier,
+        AgentEvent::now(AgentEventKind::Status {
+            status: "Starting agent".into(),
+        }),
+    );
+    state.update_session_status(&issue.identifier, RunStatus::Running);
+
     let runner = agent::AgentRunner::new(config.clone());
     let mut worker = runner
         .start_session(&workspace_dir, &prompt_text, &issue.identifier)
         .await?;
 
     // Run multi-turn agent loop
-    let success = run_agent_attempt(&mut worker, &prompt_text, config.agent.max_turns).await?;
+    let success =
+        run_agent_attempt(&mut worker, &prompt_text, config.agent.max_turns, state, &issue.identifier).await?;
+
+    if success {
+        // Post-completion pipeline: commit → review → PR
+        let hook_timeout = config.hooks.timeout();
+
+        // 1. Commit the agent's changes
+        state.push_agent_event(
+            &issue.identifier,
+            AgentEvent::now(AgentEventKind::Status {
+                status: "Committing agent changes".into(),
+            }),
+        );
+        let title_safe = issue.title.replace('\'', "'\\''");
+        let commit_script = format!(
+            "git add -A && git diff --cached --quiet || git commit -m 'fix: {}'",
+            title_safe,
+        );
+        if let Err(e) = hooks::run_hook(&commit_script, &workspace_dir, hook_timeout).await {
+            tracing::warn!(issue_id = issue.identifier, "commit hook failed: {e}");
+        }
+
+        // 2. Run review agent
+        state.push_agent_event(
+            &issue.identifier,
+            AgentEvent::now(AgentEventKind::Status {
+                status: "Running deep review".into(),
+            }),
+        );
+        let review_prompt = build_review_prompt(issue);
+        match runner
+            .start_session(&workspace_dir, &review_prompt, &issue.identifier)
+            .await
+        {
+            Ok(mut review_worker) => {
+                match run_agent_attempt(
+                    &mut review_worker,
+                    &review_prompt,
+                    config.agent.max_turns,
+                    state,
+                    &issue.identifier,
+                )
+                .await
+                {
+                    Ok(_) => {
+                        // Commit review fixes if any
+                        let review_commit =
+                            "git add -A && git diff --cached --quiet || git commit -m 'review: address code review feedback'";
+                        if let Err(e) =
+                            hooks::run_hook(review_commit, &workspace_dir, hook_timeout).await
+                        {
+                            tracing::warn!(
+                                issue_id = issue.identifier,
+                                "review commit failed: {e}"
+                            );
+                        }
+                    }
+                    Err(e) => {
+                        tracing::warn!(
+                            issue_id = issue.identifier,
+                            "review agent failed: {e}"
+                        );
+                    }
+                }
+            }
+            Err(e) => {
+                tracing::warn!(
+                    issue_id = issue.identifier,
+                    "failed to start review agent: {e}"
+                );
+            }
+        }
+
+        // 3. Push branch and open draft PR
+        state.push_agent_event(
+            &issue.identifier,
+            AgentEvent::now(AgentEventKind::Status {
+                status: "Opening draft PR".into(),
+            }),
+        );
+        let pr_title = format!("Bug {}: {}", issue.identifier, issue.title)
+            .replace('\'', "'\\''");
+        let pr_body_text = format!(
+            "Automated fix for bug **{}**: {}\n\n---\n*Opened by Symposium*",
+            issue.identifier, issue.title,
+        )
+        .replace('\'', "'\\''");
+        let pr_script = format!(
+            "git push -u origin HEAD 2>&1 && gh pr create --draft --title '{}' --body '{}' 2>&1 || true",
+            pr_title, pr_body_text,
+        );
+        match hooks::run_hook(&pr_script, &workspace_dir, hook_timeout).await {
+            Ok(()) => {
+                tracing::info!(issue_id = issue.identifier, "draft PR created");
+                state.push_agent_event(
+                    &issue.identifier,
+                    AgentEvent::now(AgentEventKind::Status {
+                        status: "Draft PR opened".into(),
+                    }),
+                );
+            }
+            Err(e) => {
+                tracing::warn!(issue_id = issue.identifier, "PR creation failed: {e}");
+                state.push_agent_event(
+                    &issue.identifier,
+                    AgentEvent::now(AgentEventKind::Error {
+                        message: format!("PR creation failed: {e}"),
+                    }),
+                );
+            }
+        }
+    }
 
     // Run after_run hook
     ws.finish(issue, success).await?;
 
     Ok(success)
 }
+
+/// Build a review-focused prompt for the second agent pass.
+fn build_review_prompt(issue: &Issue) -> String {
+    format!(
+        r#"You are reviewing changes for bug {id}: {title}.
+
+First, read `CLAUDE.md` at the repo root and any relevant subsystem `AGENTS.md` files.
+
+Then run `git diff origin/main` to see all changes on this branch.
+
+Perform a thorough code review covering:
+
+1. **Correctness** — Does the fix actually address the bug? Are there edge cases or off-by-one errors?
+2. **Error handling** — Are errors handled properly? No swallowed errors or missing error paths?
+3. **Type safety** — Are types used correctly? Any unsafe casts or implicit conversions?
+4. **Performance** — Any unnecessary allocations, N+1 queries, or hot-path regressions?
+5. **Security** — Any injection, XSS, auth bypass, or other vulnerabilities introduced?
+6. **Tests** — Are tests adequate? Do they cover the regression? Are there missing test cases?
+7. **Code quality** — Naming, duplication, dead code, or overly complex logic?
+
+Fix any real issues you find. Keep changes minimal — only fix actual problems, do not refactor working code or make stylistic changes. If no issues are found, do nothing."#,
+        id = issue.identifier,
+        title = issue.title,
+    )
+}
+
 
 /// Clean up workspaces for issues that have reached terminal states.
 async fn cleanup_terminal(

--- a/src/prompt/mod.rs
+++ b/src/prompt/mod.rs
@@ -4,6 +4,16 @@ use liquid::ParserBuilder;
 
 /// Render the prompt template with issue data.
 pub fn build_prompt(template_str: &str, issue: &Issue, attempt: Option<u32>) -> Result<String> {
+    build_prompt_with_workspace(template_str, issue, attempt, None)
+}
+
+/// Render a template with issue data and an optional workspace path.
+pub fn build_prompt_with_workspace(
+    template_str: &str,
+    issue: &Issue,
+    attempt: Option<u32>,
+    workspace: Option<&str>,
+) -> Result<String> {
     let parser = ParserBuilder::with_stdlib()
         .build()
         .map_err(|e| Error::Prompt(format!("failed to build liquid parser: {e}")))?;
@@ -34,6 +44,13 @@ pub fn build_prompt(template_str: &str, issue: &Issue, attempt: Option<u32>) -> 
         globals.insert(
             "attempt".into(),
             liquid::model::Value::scalar(attempt as i64),
+        );
+    }
+
+    if let Some(ws) = workspace {
+        globals.insert(
+            "workspace".into(),
+            liquid::model::Value::scalar(ws.to_string()),
         );
     }
 

--- a/src/server/api.rs
+++ b/src/server/api.rs
@@ -19,6 +19,7 @@ pub struct AppState {
 pub fn router(state: AppState) -> Router {
     Router::new()
         .route("/", get(dashboard))
+        .route("/issue/{id}", get(issue_detail))
         .route("/api/v1/state", get(get_state))
         .route("/api/v1/issues/{id}", get(get_issue))
         .route("/api/v1/refresh", post(refresh))
@@ -29,6 +30,15 @@ pub fn router(state: AppState) -> Router {
 async fn dashboard(State(state): State<AppState>) -> axum::response::Html<String> {
     let snapshot = state.orchestrator.snapshot();
     let html = super::dashboard::render(&snapshot);
+    axum::response::Html(html)
+}
+
+async fn issue_detail(
+    State(state): State<AppState>,
+    Path(id): Path<String>,
+) -> axum::response::Html<String> {
+    let snapshot = state.orchestrator.snapshot();
+    let html = super::dashboard::render_issue_detail(&snapshot, &id);
     axum::response::Html(html)
 }
 

--- a/src/server/dashboard.rs
+++ b/src/server/dashboard.rs
@@ -1,46 +1,97 @@
+use crate::domain::session::AgentEventKind;
 use crate::domain::state::StateSnapshot;
 
-/// Render a simple HTML dashboard from the state snapshot.
+fn html_escape(s: &str) -> String {
+    s.replace('&', "&amp;")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;")
+        .replace('"', "&quot;")
+}
+
+const STYLE: &str = r#"
+    body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif; margin: 2rem; background: #f5f5f5; }
+    h1 { color: #333; }
+    h1 a { color: #333; text-decoration: none; }
+    h2 { color: #555; margin-top: 2rem; }
+    table { border-collapse: collapse; width: 100%; background: white; border-radius: 8px; overflow: hidden; box-shadow: 0 1px 3px rgba(0,0,0,0.1); }
+    th, td { padding: 0.75rem 1rem; text-align: left; border-bottom: 1px solid #eee; }
+    th { background: #f8f9fa; font-weight: 600; color: #555; }
+    a { color: #0066cc; text-decoration: none; }
+    a:hover { text-decoration: underline; }
+    .stats { display: flex; gap: 1rem; margin: 1rem 0; }
+    .stat { background: white; padding: 1rem 1.5rem; border-radius: 8px; box-shadow: 0 1px 3px rgba(0,0,0,0.1); }
+    .stat-value { font-size: 2rem; font-weight: bold; color: #333; }
+    .stat-label { color: #888; font-size: 0.875rem; }
+    .empty { color: #999; padding: 2rem; text-align: center; }
+    .event { padding: 0.5rem 0; border-bottom: 1px solid #f0f0f0; font-size: 0.875rem; }
+    .event:last-child { border-bottom: none; }
+    .event-time { color: #999; font-family: monospace; margin-right: 0.75rem; }
+    .event-status { color: #0066cc; font-weight: 600; }
+    .event-tool { color: #7c3aed; }
+    .event-result { color: #059669; }
+    .event-error { color: #dc2626; font-weight: 600; }
+    .event-turn { color: #d97706; font-weight: 600; }
+    .event-text { color: #555; }
+    .event-detail { color: #888; font-family: monospace; font-size: 0.8rem; display: block; margin-top: 0.25rem; white-space: pre-wrap; word-break: break-all; max-height: 4rem; overflow: hidden; }
+    .meta { background: white; padding: 1rem 1.5rem; border-radius: 8px; box-shadow: 0 1px 3px rgba(0,0,0,0.1); margin: 1rem 0; }
+    .meta-row { display: flex; gap: 2rem; margin: 0.25rem 0; }
+    .meta-label { color: #888; min-width: 6rem; }
+    .events-container { background: white; border-radius: 8px; box-shadow: 0 1px 3px rgba(0,0,0,0.1); padding: 1rem 1.5rem; max-height: 70vh; overflow-y: auto; }
+"#;
+
+/// Render the main dashboard.
 pub fn render(snapshot: &StateSnapshot) -> String {
-    let running_rows: String = snapshot.running.iter().map(|entry| {
-        format!(
-            "<tr><td>{}</td><td>{}</td><td>{:?}</td><td>{}</td></tr>",
-            entry.issue.identifier,
-            entry.issue.title,
-            entry.session.status,
-            entry.session.current_turn
-        )
-    }).collect();
+    let running_rows: String = snapshot
+        .running
+        .iter()
+        .map(|entry| {
+            let last_event = entry
+                .session
+                .events
+                .last()
+                .map(|e| match &e.kind {
+                    AgentEventKind::Status { status } => status.clone(),
+                    AgentEventKind::ToolCall { name, .. } => format!("→ {name}"),
+                    AgentEventKind::ToolResult { name, .. } => format!("← {name}"),
+                    AgentEventKind::TurnComplete { turn } => format!("Turn {turn} done"),
+                    AgentEventKind::Error { message } => format!("Error: {message}"),
+                    AgentEventKind::Text { .. } => "Thinking...".into(),
+                })
+                .unwrap_or_default();
+            format!(
+                "<tr><td><a href=\"/issue/{}\">{}</a></td><td>{}</td><td>{:?}</td><td>{}</td><td>{}</td></tr>",
+                entry.issue.identifier,
+                entry.issue.identifier,
+                html_escape(&entry.issue.title),
+                entry.session.status,
+                entry.session.current_turn,
+                html_escape(&last_event),
+            )
+        })
+        .collect();
 
-    let completed_rows: String = snapshot.completed.iter().map(|entry| {
-        format!(
-            "<tr><td>{}</td><td>{}</td><td>{}</td><td>{}</td></tr>",
-            entry.issue_id,
-            if entry.success { "Success" } else { "Failed" },
-            entry.attempts,
-            entry.completed_at.format("%Y-%m-%d %H:%M:%S")
-        )
-    }).collect();
+    let completed_rows: String = snapshot
+        .completed
+        .iter()
+        .map(|entry| {
+            format!(
+                "<tr><td>{}</td><td>{}</td><td>{}</td><td>{}</td></tr>",
+                entry.issue_id,
+                if entry.success { "✓ Success" } else { "✗ Failed" },
+                entry.attempts,
+                entry.completed_at.format("%H:%M:%S")
+            )
+        })
+        .collect();
 
-    format!(r#"<!DOCTYPE html>
+    format!(
+        r#"<!DOCTYPE html>
 <html>
 <head>
-    <title>Symposium Dashboard</title>
+    <title>Symposium</title>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <style>
-        body {{ font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif; margin: 2rem; background: #f5f5f5; }}
-        h1 {{ color: #333; }}
-        h2 {{ color: #555; margin-top: 2rem; }}
-        table {{ border-collapse: collapse; width: 100%; background: white; border-radius: 8px; overflow: hidden; box-shadow: 0 1px 3px rgba(0,0,0,0.1); }}
-        th, td {{ padding: 0.75rem 1rem; text-align: left; border-bottom: 1px solid #eee; }}
-        th {{ background: #f8f9fa; font-weight: 600; color: #555; }}
-        .stats {{ display: flex; gap: 1rem; margin: 1rem 0; }}
-        .stat {{ background: white; padding: 1rem 1.5rem; border-radius: 8px; box-shadow: 0 1px 3px rgba(0,0,0,0.1); }}
-        .stat-value {{ font-size: 2rem; font-weight: bold; color: #333; }}
-        .stat-label {{ color: #888; font-size: 0.875rem; }}
-        .empty {{ color: #999; padding: 2rem; text-align: center; }}
-    </style>
+    <style>{STYLE}</style>
 </head>
 <body>
     <h1>Symposium</h1>
@@ -70,7 +121,7 @@ pub fn render(snapshot: &StateSnapshot) -> String {
     <h2>Recently Completed</h2>
     {completed_table}
 
-    <script>setTimeout(() => location.reload(), 10000);</script>
+    <script>setTimeout(() => location.reload(), 5000);</script>
 </body>
 </html>"#,
         running = snapshot.running.len(),
@@ -81,12 +132,126 @@ pub fn render(snapshot: &StateSnapshot) -> String {
         running_table = if snapshot.running.is_empty() {
             "<div class=\"empty\">No running sessions</div>".to_string()
         } else {
-            format!("<table><tr><th>Issue</th><th>Title</th><th>Status</th><th>Turns</th></tr>{running_rows}</table>")
+            format!("<table><tr><th>Issue</th><th>Title</th><th>Status</th><th>Turns</th><th>Latest</th></tr>{running_rows}</table>")
         },
         completed_table = if snapshot.completed.is_empty() {
             "<div class=\"empty\">No completed sessions yet</div>".to_string()
         } else {
             format!("<table><tr><th>Issue</th><th>Result</th><th>Attempts</th><th>Completed</th></tr>{completed_rows}</table>")
+        },
+    )
+}
+
+/// Render a detail page for a specific issue.
+pub fn render_issue_detail(snapshot: &StateSnapshot, issue_id: &str) -> String {
+    let entry = snapshot.running.iter().find(|e| e.issue.identifier == issue_id);
+
+    let Some(entry) = entry else {
+        return format!(
+            r#"<!DOCTYPE html>
+<html><head><title>Not Found</title><meta charset="utf-8"><style>{STYLE}</style></head>
+<body><h1><a href="/">← Symposium</a></h1><div class="empty">Issue {issue_id} not found in running sessions</div></body></html>"#,
+        );
+    };
+
+    let events_html: String = entry
+        .session
+        .events
+        .iter()
+        .rev()
+        .map(|event| {
+            let time = event.timestamp.format("%H:%M:%S");
+            match &event.kind {
+                AgentEventKind::Status { status } => {
+                    format!(
+                        "<div class=\"event\"><span class=\"event-time\">{time}</span><span class=\"event-status\">{}</span></div>",
+                        html_escape(status)
+                    )
+                }
+                AgentEventKind::ToolCall { name, arguments } => {
+                    format!(
+                        "<div class=\"event\"><span class=\"event-time\">{time}</span><span class=\"event-tool\">→ {}</span><span class=\"event-detail\">{}</span></div>",
+                        html_escape(name),
+                        html_escape(arguments)
+                    )
+                }
+                AgentEventKind::ToolResult { name, truncated } => {
+                    format!(
+                        "<div class=\"event\"><span class=\"event-time\">{time}</span><span class=\"event-result\">← {}</span><span class=\"event-detail\">{}</span></div>",
+                        html_escape(name),
+                        html_escape(truncated)
+                    )
+                }
+                AgentEventKind::TurnComplete { turn } => {
+                    format!(
+                        "<div class=\"event\"><span class=\"event-time\">{time}</span><span class=\"event-turn\">Turn {turn} complete</span></div>"
+                    )
+                }
+                AgentEventKind::Error { message } => {
+                    format!(
+                        "<div class=\"event\"><span class=\"event-time\">{time}</span><span class=\"event-error\">Error: {}</span></div>",
+                        html_escape(message)
+                    )
+                }
+                AgentEventKind::Text { text } => {
+                    let preview: String = text.chars().take(200).collect();
+                    format!(
+                        "<div class=\"event\"><span class=\"event-time\">{time}</span><span class=\"event-text\">{}</span></div>",
+                        html_escape(&preview)
+                    )
+                }
+            }
+        })
+        .collect();
+
+    let desc = entry
+        .issue
+        .description
+        .as_deref()
+        .unwrap_or("No description");
+
+    format!(
+        r#"<!DOCTYPE html>
+<html>
+<head>
+    <title>Issue {id} - Symposium</title>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <style>{STYLE}</style>
+</head>
+<body>
+    <h1><a href="/">← Symposium</a></h1>
+    <h2>{id}: {title}</h2>
+
+    <div class="meta">
+        <div class="meta-row"><span class="meta-label">Status</span><span>{status:?}</span></div>
+        <div class="meta-row"><span class="meta-label">Turn</span><span>{turn}</span></div>
+        <div class="meta-row"><span class="meta-label">Priority</span><span>{priority}</span></div>
+        <div class="meta-row"><span class="meta-label">Started</span><span>{started}</span></div>
+        <div class="meta-row"><span class="meta-label">Last Activity</span><span>{last_activity}</span></div>
+        <div class="meta-row"><span class="meta-label">Description</span><span>{description}</span></div>
+    </div>
+
+    <h2>Agent Activity</h2>
+    <div class="events-container">
+        {events}
+    </div>
+
+    <script>setTimeout(() => location.reload(), 3000);</script>
+</body>
+</html>"#,
+        id = entry.issue.identifier,
+        title = html_escape(&entry.issue.title),
+        status = entry.session.status,
+        turn = entry.session.current_turn,
+        priority = html_escape(entry.issue.priority.as_deref().unwrap_or("—")),
+        started = entry.session.started_at.format("%H:%M:%S"),
+        last_activity = entry.session.last_activity.format("%H:%M:%S"),
+        description = html_escape(desc),
+        events = if events_html.is_empty() {
+            "<div class=\"empty\">No events yet</div>".to_string()
+        } else {
+            events_html
         },
     )
 }

--- a/src/tracker/mcp_http.rs
+++ b/src/tracker/mcp_http.rs
@@ -45,6 +45,17 @@ impl HttpMcpClient {
         self.send_notification("notifications/initialized", serde_json::json!({}))
             .await?;
 
+        // Discover available tools
+        if let Ok(tools_result) = self.send_request("tools/list", serde_json::json!({})).await
+            && let Some(tools) = tools_result.get("tools").and_then(|v| v.as_array())
+        {
+            let names: Vec<&str> = tools
+                .iter()
+                .filter_map(|t| t.get("name").and_then(|n| n.as_str()))
+                .collect();
+            tracing::info!(tools = ?names, "MCP server tools");
+        }
+
         Ok(())
     }
 

--- a/src/tracker/notion.rs
+++ b/src/tracker/notion.rs
@@ -64,10 +64,17 @@ impl NotionTracker {
             .map(|s| format!("'{s}'"))
             .collect::<Vec<_>>()
             .join(", ");
-        format!(
+        let mut query = format!(
             "SELECT * FROM \"{ds_id}\" WHERE \"{}\" IN ({status_list})",
             self.config.property_status
-        )
+        );
+        if let Some(ref user_id) = self.config.assignee_user_id {
+            query.push_str(&format!(
+                " AND \"{}\" LIKE '%{user_id}%'",
+                self.config.property_assignee
+            ));
+        }
+        query
     }
 
     /// Unwrap the MCP tool response to get the inner data.

--- a/src/workspace/hooks.rs
+++ b/src/workspace/hooks.rs
@@ -24,21 +24,29 @@ pub async fn run_hook_with_env(
     cmd.stdout(std::process::Stdio::piped());
     cmd.stderr(std::process::Stdio::piped());
 
-    let mut child = cmd.spawn().map_err(|e| {
+    let child = cmd.spawn().map_err(|e| {
         Error::Hook(format!("failed to spawn hook: {e}"))
     })?;
 
-    match tokio::time::timeout(timeout, child.wait()).await {
-        Ok(Ok(status)) => {
-            if status.success() {
+    match tokio::time::timeout(timeout, child.wait_with_output()).await {
+        Ok(Ok(output)) => {
+            if output.status.success() {
                 Ok(())
             } else {
-                Err(Error::Hook(format!("hook exited with {status}")))
+                let stderr = String::from_utf8_lossy(&output.stderr);
+                let stdout = String::from_utf8_lossy(&output.stdout);
+                if !stderr.is_empty() {
+                    tracing::warn!(stderr = %stderr.trim(), "hook stderr");
+                }
+                if !stdout.is_empty() {
+                    tracing::debug!(stdout = %stdout.trim(), "hook stdout");
+                }
+                Err(Error::Hook(format!("hook exited with {}", output.status)))
             }
         }
         Ok(Err(e)) => Err(Error::Hook(format!("hook I/O error: {e}"))),
         Err(_) => {
-            let _ = child.start_kill();
+            // child was consumed by wait_with_output — process already finished or will be reaped
             Err(Error::Hook(format!(
                 "hook timed out after {}s",
                 timeout.as_secs()

--- a/src/workspace/mod.rs
+++ b/src/workspace/mod.rs
@@ -5,7 +5,7 @@ use crate::config::schema::ServiceConfig;
 use crate::domain::issue::Issue;
 use crate::error::{Error, Result};
 use crate::prompt;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use tokio::sync::watch;
 
 pub struct WorkspaceManager {
@@ -31,9 +31,20 @@ impl WorkspaceManager {
         Ok(dir)
     }
 
-    /// Render a hook script through Liquid with issue context.
-    fn render_hook(&self, hook: &str, issue: &Issue, attempt: Option<u32>) -> Result<String> {
-        prompt::build_prompt(hook, issue, attempt)
+    /// Render a hook script through Liquid with issue context and workspace path.
+    fn render_hook(
+        &self,
+        hook: &str,
+        issue: &Issue,
+        attempt: Option<u32>,
+        workspace: &Path,
+    ) -> Result<String> {
+        prompt::build_prompt_with_workspace(
+            hook,
+            issue,
+            attempt,
+            workspace.to_str(),
+        )
     }
 
     /// Ensure the workspace directory exists, run after_create hook if newly created.
@@ -42,15 +53,31 @@ impl WorkspaceManager {
         let newly_created = !dir.exists();
 
         if newly_created {
-            tokio::fs::create_dir_all(&dir).await.map_err(|e| {
-                Error::Workspace(format!("failed to create workspace {}: {e}", dir.display()))
-            })?;
-            tracing::info!(issue_key = issue.identifier, path = %dir.display(), "created workspace");
-
             let config = self.config_rx.borrow().clone();
             if let Some(hook) = &config.hooks.after_create {
-                let rendered = self.render_hook(hook, issue, None)?;
-                hooks::run_hook(&rendered, &dir, config.hooks.timeout()).await?;
+                // Ensure parent dir exists; the hook itself creates the workspace
+                // (e.g. git worktree add creates the target directory)
+                if let Some(parent) = dir.parent() {
+                    tokio::fs::create_dir_all(parent).await.map_err(|e| {
+                        Error::Workspace(format!(
+                            "failed to create workspace parent {}: {e}",
+                            parent.display()
+                        ))
+                    })?;
+                }
+                tracing::info!(issue_key = issue.identifier, path = %dir.display(), "creating workspace");
+                let rendered = self.render_hook(hook, issue, None, &dir)?;
+                // Run hook from the parent directory since workspace doesn't exist yet
+                let cwd = dir.parent().unwrap_or(&dir);
+                hooks::run_hook(&rendered, cwd, config.hooks.timeout()).await?;
+            } else {
+                tokio::fs::create_dir_all(&dir).await.map_err(|e| {
+                    Error::Workspace(format!(
+                        "failed to create workspace {}: {e}",
+                        dir.display()
+                    ))
+                })?;
+                tracing::info!(issue_key = issue.identifier, path = %dir.display(), "created workspace");
             }
         }
 
@@ -62,7 +89,7 @@ impl WorkspaceManager {
         let dir = self.workspace_dir(&issue.identifier)?;
         let config = self.config_rx.borrow().clone();
         if let Some(hook) = &config.hooks.before_run {
-            let rendered = self.render_hook(hook, issue, attempt)?;
+            let rendered = self.render_hook(hook, issue, attempt, &dir)?;
             hooks::run_hook(&rendered, &dir, config.hooks.timeout()).await?;
         }
         Ok(dir)
@@ -73,7 +100,7 @@ impl WorkspaceManager {
         let dir = self.workspace_dir(&issue.identifier)?;
         let config = self.config_rx.borrow().clone();
         if let Some(hook) = &config.hooks.after_run {
-            let rendered = self.render_hook(hook, issue, None)?;
+            let rendered = self.render_hook(hook, issue, None, &dir)?;
             let mut env = std::collections::HashMap::new();
             env.insert(
                 "RUN_SUCCESS".to_string(),


### PR DESCRIPTION
## Summary

- **Agent runtime rewrite**: Switches from JSON-RPC app-server to `claude -p --output-format stream-json`, fixing pipe closure, nesting detection, and stdin EOF signaling
- **Post-completion pipeline**: After a successful agent run, automatically commits changes, runs a deep review agent pass, and opens a draft PR
- **Dispatch fixes**: Prevents re-dispatching successfully completed issues; handles dirty working trees in `before_run` hooks
- **Dashboard**: Live event streaming with per-issue detail pages, auto-refresh, and color-coded event types

## Test plan

- [x] `cargo check` — clean
- [x] `cargo clippy` — no warnings
- [x] `cargo test` — 18/18 pass
- [x] `cargo build --release` — clean
- [ ] End-to-end: run orchestrator against Notion bugs database, verify agent completes, review pass runs, draft PR opens