### PR TITLE
Skip issues with linked PRs, fix PR titles, and UI tweaks

### DIFF
--- a/src/agent/worker.rs
+++ b/src/agent/worker.rs
@@ -47,7 +47,6 @@ pub enum StreamEvent {
 pub async fn run_agent_attempt(
     worker: &mut AgentWorker,
     _initial_prompt: &str,
-    _max_turns: u32,
     state: &crate::domain::state::OrchestratorState,
     issue_id: &str,
 ) -> Result<bool> {
@@ -86,50 +85,48 @@ pub async fn run_agent_attempt(
                 }
             }
             "assistant" => {
-                // Extract tool use or text from the message
                 if let Some(message) = msg.get("message")
                     && let Some(content) = message.get("content").and_then(|v| v.as_array())
                 {
-                        for block in content {
-                            let block_type =
-                                block.get("type").and_then(|v| v.as_str()).unwrap_or("");
-                            match block_type {
-                                "text" => {
-                                    if let Some(text) = block.get("text").and_then(|v| v.as_str())
-                                    {
-                                        let preview: String = text.chars().take(300).collect();
-                                        state.push_agent_event(
-                                            issue_id,
-                                            AgentEvent::now(AgentEventKind::Text {
-                                                text: preview,
-                                            }),
-                                        );
-                                    }
-                                }
-                                "tool_use" => {
-                                    let name = block
-                                        .get("name")
-                                        .and_then(|v| v.as_str())
-                                        .unwrap_or("unknown");
-                                    let input = block
-                                        .get("input")
-                                        .map(|v| v.to_string())
-                                        .unwrap_or_default();
-                                    let truncated: String = input.chars().take(200).collect();
+                    for block in content {
+                        let block_type =
+                            block.get("type").and_then(|v| v.as_str()).unwrap_or("");
+                        match block_type {
+                            "text" => {
+                                if let Some(text) = block.get("text").and_then(|v| v.as_str())
+                                {
+                                    let preview: String = text.chars().take(300).collect();
                                     state.push_agent_event(
                                         issue_id,
-                                        AgentEvent::now(AgentEventKind::ToolCall {
-                                            name: name.to_string(),
-                                            arguments: truncated,
+                                        AgentEvent::now(AgentEventKind::Text {
+                                            text: preview,
                                         }),
                                     );
-                                    state.increment_turn(issue_id);
                                 }
-                                _ => {}
                             }
+                            "tool_use" => {
+                                let name = block
+                                    .get("name")
+                                    .and_then(|v| v.as_str())
+                                    .unwrap_or("unknown");
+                                let input = block
+                                    .get("input")
+                                    .map(|v| v.to_string())
+                                    .unwrap_or_default();
+                                let truncated: String = input.chars().take(200).collect();
+                                state.push_agent_event(
+                                    issue_id,
+                                    AgentEvent::now(AgentEventKind::ToolCall {
+                                        name: name.to_string(),
+                                        arguments: truncated,
+                                    }),
+                                );
+                            }
+                            _ => {}
                         }
                     }
                 }
+            }
             "result" => {
                 let is_error = msg.get("is_error").and_then(|v| v.as_bool()).unwrap_or(false);
                 let result_text = msg

--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -33,6 +33,8 @@ pub struct TrackerConfig {
     pub property_assignee: String,
     /// Filter issues to only those assigned to this user ID.
     pub assignee_user_id: Option<String>,
+    /// Skip issues where this property is non-null (e.g. a linked PR relation).
+    pub skip_if_set: Option<String>,
 }
 
 impl Default for TrackerConfig {
@@ -51,6 +53,7 @@ impl Default for TrackerConfig {
             property_description: "Description".to_string(),
             property_assignee: "Assignee".to_string(),
             assignee_user_id: None,
+            skip_if_set: None,
         }
     }
 }
@@ -117,14 +120,12 @@ impl HooksConfig {
 #[serde(default)]
 pub struct AgentConfig {
     pub max_concurrent_agents: usize,
-    pub max_turns: u32,
 }
 
 impl Default for AgentConfig {
     fn default() -> Self {
         Self {
             max_concurrent_agents: 5,
-            max_turns: 20,
         }
     }
 }

--- a/src/domain/session.rs
+++ b/src/domain/session.rs
@@ -7,7 +7,6 @@ const MAX_EVENTS: usize = 200;
 pub struct LiveSession {
     pub issue_id: String,
     pub thread_id: Option<String>,
-    pub current_turn: u32,
     pub status: RunStatus,
     pub started_at: DateTime<Utc>,
     pub last_activity: DateTime<Utc>,
@@ -21,7 +20,6 @@ impl LiveSession {
         Self {
             issue_id,
             thread_id: None,
-            current_turn: 0,
             status: RunStatus::Starting,
             started_at: now,
             last_activity: now,

--- a/src/domain/state.rs
+++ b/src/domain/state.rs
@@ -172,13 +172,6 @@ impl OrchestratorState {
         }
     }
 
-    pub fn increment_turn(&self, issue_id: &str) {
-        let mut inner = self.inner.lock().unwrap();
-        if let Some(entry) = inner.running.get_mut(issue_id) {
-            entry.session.current_turn += 1;
-            entry.session.last_activity = Utc::now();
-        }
-    }
 
     pub fn snapshot(&self) -> StateSnapshot {
         let inner = self.inner.lock().unwrap();

--- a/src/orchestrator/tick.rs
+++ b/src/orchestrator/tick.rs
@@ -240,7 +240,7 @@ async fn run_worker(
 
     // Run multi-turn agent loop
     let success =
-        run_agent_attempt(&mut worker, &prompt_text, config.agent.max_turns, state, &issue.identifier).await?;
+        run_agent_attempt(&mut worker, &prompt_text, state, &issue.identifier).await?;
 
     if success {
         // Post-completion pipeline: commit → review → PR
@@ -278,7 +278,6 @@ async fn run_worker(
                 match run_agent_attempt(
                     &mut review_worker,
                     &review_prompt,
-                    config.agent.max_turns,
                     state,
                     &issue.identifier,
                 )
@@ -320,7 +319,7 @@ async fn run_worker(
                 status: "Opening draft PR".into(),
             }),
         );
-        let pr_title = format!("Bug {}: {}", issue.identifier, issue.title)
+        let pr_title = format!("[BUG-{}] {}", issue.identifier, issue.title)
             .replace('\'', "'\\''");
         let pr_body_text = format!(
             "Automated fix for bug **{}**: {}\n\n---\n*Opened by Symposium*",

--- a/src/server/dashboard.rs
+++ b/src/server/dashboard.rs
@@ -59,12 +59,11 @@ pub fn render(snapshot: &StateSnapshot) -> String {
                 })
                 .unwrap_or_default();
             format!(
-                "<tr><td><a href=\"/issue/{}\">{}</a></td><td>{}</td><td>{:?}</td><td>{}</td><td>{}</td></tr>",
+                "<tr><td><a href=\"/issue/{}\">{}</a></td><td>{}</td><td>{:?}</td><td>{}</td></tr>",
                 entry.issue.identifier,
                 entry.issue.identifier,
                 html_escape(&entry.issue.title),
                 entry.session.status,
-                entry.session.current_turn,
                 html_escape(&last_event),
             )
         })
@@ -132,7 +131,7 @@ pub fn render(snapshot: &StateSnapshot) -> String {
         running_table = if snapshot.running.is_empty() {
             "<div class=\"empty\">No running sessions</div>".to_string()
         } else {
-            format!("<table><tr><th>Issue</th><th>Title</th><th>Status</th><th>Turns</th><th>Latest</th></tr>{running_rows}</table>")
+            format!("<table><tr><th>Issue</th><th>Title</th><th>Status</th><th>Latest</th></tr>{running_rows}</table>")
         },
         completed_table = if snapshot.completed.is_empty() {
             "<div class=\"empty\">No completed sessions yet</div>".to_string()
@@ -158,7 +157,6 @@ pub fn render_issue_detail(snapshot: &StateSnapshot, issue_id: &str) -> String {
         .session
         .events
         .iter()
-        .rev()
         .map(|event| {
             let time = event.timestamp.format("%H:%M:%S");
             match &event.kind {
@@ -225,7 +223,6 @@ pub fn render_issue_detail(snapshot: &StateSnapshot, issue_id: &str) -> String {
 
     <div class="meta">
         <div class="meta-row"><span class="meta-label">Status</span><span>{status:?}</span></div>
-        <div class="meta-row"><span class="meta-label">Turn</span><span>{turn}</span></div>
         <div class="meta-row"><span class="meta-label">Priority</span><span>{priority}</span></div>
         <div class="meta-row"><span class="meta-label">Started</span><span>{started}</span></div>
         <div class="meta-row"><span class="meta-label">Last Activity</span><span>{last_activity}</span></div>
@@ -243,7 +240,6 @@ pub fn render_issue_detail(snapshot: &StateSnapshot, issue_id: &str) -> String {
         id = entry.issue.identifier,
         title = html_escape(&entry.issue.title),
         status = entry.session.status,
-        turn = entry.session.current_turn,
         priority = html_escape(entry.issue.priority.as_deref().unwrap_or("—")),
         started = entry.session.started_at.format("%H:%M:%S"),
         last_activity = entry.session.last_activity.format("%H:%M:%S"),

--- a/src/tracker/notion.rs
+++ b/src/tracker/notion.rs
@@ -74,6 +74,9 @@ impl NotionTracker {
                 self.config.property_assignee
             ));
         }
+        if let Some(ref prop) = self.config.skip_if_set {
+            query.push_str(&format!(" AND \"{prop}\" IS NULL"));
+        }
         query
     }
 


### PR DESCRIPTION
## Summary

- **Skip issues with linked PRs**: New `skip_if_set` tracker config adds `IS NULL` filter to candidate query — issues with a `🆕 GitHub Pull Requests` relation are excluded
- **PR title format**: `[BUG-316205] Fix title here` for Notion auto-linking
- **Remove turn counter**: `current_turn`, `max_turns`, `increment_turn` removed — Claude's `result` event reports authoritative `num_turns`
- **Chronological events**: Detail page now renders oldest-first like a standard Claude session

## Test plan

- [x] `cargo clippy` — no warnings
- [x] `cargo check` — clean
- [ ] Verify orchestrator skips issues with linked PRs