### PR TITLE
Add agent subdirectory config and auto-scroll event log

### DIFF
--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -80,12 +80,15 @@ impl PollingConfig {
 #[serde(default)]
 pub struct WorkspaceConfig {
     pub root: String,
+    /// Subdirectory within the workspace to use as the agent's working directory.
+    pub agent_subdirectory: Option<String>,
 }
 
 impl Default for WorkspaceConfig {
     fn default() -> Self {
         Self {
             root: "~/symposium_workspaces".to_string(),
+            agent_subdirectory: None,
         }
     }
 }

--- a/src/orchestrator/tick.rs
+++ b/src/orchestrator/tick.rs
@@ -233,9 +233,15 @@ async fn run_worker(
     );
     state.update_session_status(&issue.identifier, RunStatus::Running);
 
+    // Use agent_subdirectory if configured (e.g. "mail-ios" within the repo worktree)
+    let agent_dir = match &config.workspace.agent_subdirectory {
+        Some(sub) => workspace_dir.join(sub),
+        None => workspace_dir.clone(),
+    };
+
     let runner = agent::AgentRunner::new(config.clone());
     let mut worker = runner
-        .start_session(&workspace_dir, &prompt_text, &issue.identifier)
+        .start_session(&agent_dir, &prompt_text, &issue.identifier)
         .await?;
 
     // Run multi-turn agent loop
@@ -255,7 +261,7 @@ async fn run_worker(
         );
         let review_prompt = build_review_prompt(issue);
         match runner
-            .start_session(&workspace_dir, &review_prompt, &issue.identifier)
+            .start_session(&agent_dir, &review_prompt, &issue.identifier)
             .await
         {
             Ok(mut review_worker) => {

--- a/src/server/dashboard.rs
+++ b/src/server/dashboard.rs
@@ -234,7 +234,19 @@ pub fn render_issue_detail(snapshot: &StateSnapshot, issue_id: &str) -> String {
         {events}
     </div>
 
-    <script>setTimeout(() => location.reload(), 3000);</script>
+    <script>
+    (() => {{
+        const el = document.querySelector('.events-container');
+        if (!el) return;
+        const wasAtBottom = sessionStorage.getItem('eventsAtBottom') !== 'false';
+        if (wasAtBottom) el.scrollTop = el.scrollHeight;
+        setTimeout(() => {{
+            const atBottom = el.scrollHeight - el.scrollTop - el.clientHeight < 50;
+            sessionStorage.setItem('eventsAtBottom', atBottom);
+            location.reload();
+        }}, 3000);
+    }})();
+    </script>
 </body>
 </html>"#,
         id = entry.issue.identifier,


### PR DESCRIPTION
## Summary

- **agent_subdirectory**: New workspace config so agents run in a subdirectory (e.g. `mail-ios`) while worktree creation, hooks, and git push stay at the repo root
- **Auto-scroll**: Detail page event log scrolls to bottom by default; if user scrolls up to read history, it stays put across reloads

## Test plan

- [x] `cargo clippy` — clean
- [ ] Verify agent cwd is `{workspace}/mail-ios`
- [ ] Verify scroll-to-bottom works and respects manual scroll-up