### PR TITLE
Harden post-completion pipeline and update example workflow

### DIFF
--- a/WORKFLOW.example.md
+++ b/WORKFLOW.example.md
@@ -3,68 +3,98 @@
 Copy this file to `WORKFLOW.<name>.md` and fill in your values.
 Files matching `WORKFLOW.*.md` (except this example) are gitignored.
 
+---
+
+The file uses YAML front matter for configuration, followed by a Liquid
+template that becomes the prompt sent to each agent.
+
+## Configuration
+
 ```yaml
+---
 tracker:
   kind: notion
-  # Option A: stdio MCP server (default)
+  # Option A: stdio MCP server (public npm package)
   mcp_command: "npx -y @notionhq/notion-mcp-server"
-  # Option B: HTTP MCP server with OAuth
-  # mcp_url: "https://your-notion-mcp-server.example.com"
-  database_id: "your-notion-database-id"
-  active_states:
-    - "Todo"
-    - "In Progress"
-  terminal_states:
-    - "Done"
-    - "Cancelled"
-  property_id: "ID"
-  property_title: "Name"
+  # Option B: HTTP MCP server (e.g. Notion internal dev endpoint)
+  # mcp_url: "https://mcp.notion.com/readonly"
+  database_id: "your-database-uuid"
+  active_states: ["On Deck", "In Progress", "Backlog"]
+  terminal_states: ["Fixed", "Won't Fix", "Can't Fix", "No Longer Relevant"]
+  property_id: "userDefined:ID"
+  property_title: "Task Name"
   property_status: "Status"
   property_priority: "Priority"
   property_description: "Description"
+  # Optional: only pick up issues assigned to this Notion user ID
+  # assignee_user_id: "your-notion-user-uuid"
+  # Optional: skip issues where this relation property is non-null (e.g. linked PRs)
+  # skip_if_set: "GitHub Pull Requests"
 
 polling:
   interval_ms: 30000
 
 workspace:
-  root: "~/symposium_workspaces"
+  root: "~/symposium_workspaces/my-project"
+  # Optional: run the agent in a subdirectory of the workspace
+  # agent_subdirectory: "packages/frontend"
 
 hooks:
+  # Runs once when a new workspace is created for an issue.
+  # Use git worktree for fast, lightweight checkouts from a local repo:
   after_create: |
-    cd {{ workspace }}
-    git clone {{ repo_url }} . 2>/dev/null || true
-    git checkout -b symposium/{{ issue.identifier | downcase }}
-  after_run: |
-    cd {{ workspace }}
-    git add -A
-    git commit -m "{{ issue.identifier }}: {{ issue.title }}" --allow-empty
+    git -C ~/Developer/my-org/my-repo worktree add {{ workspace }} -b symposium/bug-{{ issue.identifier }}
+  # Optional: runs before each agent attempt (retries included)
+  # before_run: |
+  #   git fetch origin main && git rebase origin/main
+  # Optional: runs after each agent attempt
+  # after_run: |
+  #   echo "Agent finished with RUN_SUCCESS=$RUN_SUCCESS"
 
 agent:
-  max_concurrent_agents: 5
-  max_turns: 20
+  max_concurrent_agents: 3
 
 codex:
-  command: "claude-code app-server"
-  turn_timeout_ms: 3600000
-  stall_timeout_ms: 300000
+  command: "/usr/local/bin/claude"
+  turn_timeout_ms: 3600000    # 1 hour max per agent session
+  stall_timeout_ms: 300000    # 5 min with no activity → stalled
 
 server:
   port: 8080
+---
 ```
 
 ## Prompt Template
 
-Below is the Liquid template sent to the coding agent for each issue.
+Everything after the YAML front matter closing `---` is a Liquid template.
+It is rendered per-issue and sent to the agent as its initial prompt via stdin.
 
-```
-You are working on issue {{ issue.identifier }}: {{ issue.title }}.
+Available variables:
+- `{{ issue.identifier }}` — issue ID (e.g. "316205")
+- `{{ issue.title }}` — issue title
+- `{{ issue.description }}` — issue description/notes
+- `{{ issue.status }}` — current status
+- `{{ issue.priority }}` — priority level
+- `{{ attempt }}` — retry attempt number (nil on first run)
 
-Status: {{ issue.status }}
-{% if issue.priority %}Priority: {{ issue.priority }}{% endif %}
-{% if issue.description %}
-## Description
+```liquid
+You are working on bug {{ issue.identifier }}: {{ issue.title }}.
+
+{% if issue.priority %}Severity: {{ issue.priority }}{% endif %}
+
 {{ issue.description }}
-{% endif %}
 
-Work in the directory: {{ workspace }}
+Before starting, read `CLAUDE.md` at the repo root for project conventions.
+
+This is a bug fix. Focus on:
+1. First, rebase on the latest main: `git fetch origin main && git rebase origin/main`
+2. Reproducing the issue (read the bug description carefully)
+3. Finding the root cause
+4. Implementing the minimal fix
+5. Writing or updating tests to cover the regression
+6. Commit your changes with `git add` and `git commit` using a descriptive message
+
+{% if attempt %}
+This is retry attempt {{ attempt }}. Review what happened in the previous attempt and continue from where you left off.
+{% endif %}
 ```

--- a/src/orchestrator/tick.rs
+++ b/src/orchestrator/tick.rs
@@ -302,9 +302,10 @@ async fn run_worker(
             "Automated fix for bug **{}**: {}\n\n---\n*Opened by Symposium*",
             issue.identifier, issue.title,
         );
-        // Write title/body to temp files to avoid shell escaping issues with special characters
-        let title_file = workspace_dir.join(".symposium-pr-title");
-        let body_file = workspace_dir.join(".symposium-pr-body");
+        // Write title/body to temp files outside the workspace to avoid accidental git add
+        let tmp = std::env::temp_dir();
+        let title_file = tmp.join(format!("symposium-pr-title-{}", issue.identifier));
+        let body_file = tmp.join(format!("symposium-pr-body-{}", issue.identifier));
         let _ = tokio::fs::write(&title_file, &pr_title).await;
         let _ = tokio::fs::write(&body_file, &pr_body_text).await;
         let pr_script = format!(


### PR DESCRIPTION
## Summary

- **PR temp files** written to `/tmp/` instead of workspace root to prevent accidental `git add`
- **WORKFLOW.example.md** rewritten to reflect current architecture: git worktree, agent-driven rebase/commit, `skip_if_set`, `agent_subdirectory`, no `max_turns`

## Test plan

- [x] `cargo clippy` — clean
- [ ] Verify PR creation still works with temp files in /tmp