### PR TITLE
Fix stall detection to prevent worktree collisions

### DIFF
--- a/src/orchestrator/reconcile.rs
+++ b/src/orchestrator/reconcile.rs
@@ -3,13 +3,22 @@ use crate::domain::state::OrchestratorState;
 use chrono::Utc;
 
 /// Check for stalled workers (no activity within stall_timeout).
+///
+/// Currently warn-only. We do NOT mark sessions as done here because the
+/// spawned tokio task and agent process are still running — removing the
+/// session from state without killing the process causes retry agents to
+/// collide in the same worktree. The agent's own `turn_timeout_ms` is the
+/// real safeguard against hangs.
 pub fn check_stalled(state: &OrchestratorState, config: &ServiceConfig) {
     let stall_timeout = config.codex.stall_timeout();
     let now = Utc::now();
     let stalled = state.find_stalled_sessions(now, stall_timeout);
 
     for issue_id in stalled {
-        tracing::warn!(issue_id, "session stalled, marking for retry");
-        state.mark_worker_done(&issue_id, false, Some("stall timeout".into()));
+        tracing::warn!(
+            issue_id,
+            stall_timeout_secs = stall_timeout.as_secs(),
+            "session appears stalled (no events within timeout) — agent process still running"
+        );
     }
 }

--- a/src/orchestrator/tick.rs
+++ b/src/orchestrator/tick.rs
@@ -137,8 +137,12 @@ fn dispatch_retry(
 ) {
     let issue_id = retry.issue_id.clone();
 
-    // We need the issue data — check if we still have it in completed or re-fetch
-    // For retries, we'll create a minimal issue from the retry entry
+    // Guard: don't dispatch a retry if the issue is still running (e.g. stale retry entry)
+    if state.is_running(&issue_id) {
+        tracing::warn!(issue_id, "skipping retry — session still running");
+        return;
+    }
+
     tracing::info!(issue_id, attempt = retry.attempt, "dispatching retry");
 
     let config = config.clone();


### PR DESCRIPTION
## Summary

- Makes `check_stalled` warn-only instead of calling `mark_worker_done`, which was removing sessions from state without killing the actual agent process — causing retry agents to collide in the same worktree
- Adds a guard in `dispatch_retry` to skip retries for issues that are still running
- The agent's own `turn_timeout_ms` (1 hour) remains the real safeguard against hangs

## Test plan

- [ ] Start symposium with long-running agents
- [ ] Verify stall warnings appear in logs but sessions are not killed
- [ ] Verify no worktree collisions on retry dispatch