### PR TITLE
Persist completed session logs for post-run viewing

### DIFF
--- a/src/domain/state.rs
+++ b/src/domain/state.rs
@@ -1,6 +1,6 @@
 use super::issue::Issue;
 use super::retry::RetryEntry;
-use super::session::LiveSession;
+use super::session::{AgentEvent, LiveSession, RunStatus};
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
@@ -43,12 +43,16 @@ pub struct RunningEntry {
     pub workflow_id: String,
 }
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CompletedEntry {
     pub issue_id: String,
+    pub issue: Issue,
     pub success: bool,
     pub error: Option<String>,
+    pub started_at: DateTime<Utc>,
     pub completed_at: DateTime<Utc>,
+    pub status: RunStatus,
+    pub events: Vec<AgentEvent>,
     pub attempts: u32,
     pub workflow_id: String,
 }
@@ -69,6 +73,7 @@ pub struct StateSnapshot {
 }
 
 const OPEN_PRS_FILE: &str = "open_prs.json";
+const COMPLETED_FILE: &str = "completed_sessions.json";
 
 impl OrchestratorState {
     pub fn new() -> Self {
@@ -84,18 +89,22 @@ impl OrchestratorState {
         }
     }
 
-    /// Create state with persistence: loads tracked PRs from disk and
-    /// persists changes on every `track_pr` / `untrack_pr` / `mark_pr_addressed`.
+    /// Create state with persistence: loads tracked PRs and completed sessions
+    /// from disk and persists changes on mutations.
     pub fn with_persistence(state_dir: PathBuf) -> Self {
         let open_prs = Self::load_open_prs(&state_dir);
         if !open_prs.is_empty() {
             tracing::info!(count = open_prs.len(), "restored tracked PRs from disk");
         }
+        let completed = Self::load_completed(&state_dir);
+        if !completed.is_empty() {
+            tracing::info!(count = completed.len(), "restored completed sessions from disk");
+        }
         Self {
             inner: Arc::new(Mutex::new(StateInner {
                 running: HashMap::new(),
                 retries: HashMap::new(),
-                completed: Vec::new(),
+                completed,
                 tokens: TokenTotals::default(),
                 open_prs,
                 state_dir: Some(state_dir),
@@ -129,9 +138,13 @@ impl OrchestratorState {
                 Some(ref d) => d.clone(),
                 None => return,
             };
-            let json = serde_json::to_string_pretty(&inner.open_prs)
-                .unwrap_or_else(|_| "{}".to_string());
-            (dir, json)
+            match serde_json::to_string_pretty(&inner.open_prs) {
+                Ok(json) => (dir, json),
+                Err(e) => {
+                    tracing::warn!("failed to serialize PR state, skipping persist: {e}");
+                    return;
+                }
+            }
         };
         let file = state_dir.join(OPEN_PRS_FILE);
         if let Err(e) = std::fs::create_dir_all(&state_dir) {
@@ -140,6 +153,50 @@ impl OrchestratorState {
         }
         if let Err(e) = std::fs::write(&file, json) {
             tracing::warn!(path = %file.display(), "failed to persist PR state: {e}");
+        }
+    }
+
+    fn load_completed(state_dir: &Path) -> Vec<CompletedEntry> {
+        let file = state_dir.join(COMPLETED_FILE);
+        let data = match std::fs::read_to_string(&file) {
+            Ok(d) => d,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Vec::new(),
+            Err(e) => {
+                tracing::warn!(path = %file.display(), "failed to read completed sessions: {e}");
+                return Vec::new();
+            }
+        };
+        match serde_json::from_str(&data) {
+            Ok(entries) => entries,
+            Err(e) => {
+                tracing::warn!(path = %file.display(), "failed to parse completed sessions: {e}");
+                Vec::new()
+            }
+        }
+    }
+
+    fn persist_completed(&self) {
+        let (state_dir, json) = {
+            let inner = self.inner.lock().unwrap();
+            let dir = match inner.state_dir {
+                Some(ref d) => d.clone(),
+                None => return,
+            };
+            match serde_json::to_string_pretty(&inner.completed) {
+                Ok(json) => (dir, json),
+                Err(e) => {
+                    tracing::warn!("failed to serialize completed sessions, skipping persist: {e}");
+                    return;
+                }
+            }
+        };
+        let file = state_dir.join(COMPLETED_FILE);
+        if let Err(e) = std::fs::create_dir_all(&state_dir) {
+            tracing::warn!(path = %state_dir.display(), "failed to create state dir: {e}");
+            return;
+        }
+        if let Err(e) = std::fs::write(&file, json) {
+            tracing::warn!(path = %file.display(), "failed to persist completed sessions: {e}");
         }
     }
 
@@ -190,25 +247,30 @@ impl OrchestratorState {
     }
 
     pub fn mark_worker_done(&self, state_key: &str, success: bool, error: Option<String>) {
-        let mut inner = self.inner.lock().unwrap();
-        let (attempts, workflow_id) = inner
-            .running
-            .get(state_key)
-            .map(|e| (e.session.attempts.len() as u32, e.workflow_id.clone()))
-            .unwrap_or((0, String::new()));
-        inner.running.remove(state_key);
-        inner.completed.push(CompletedEntry {
-            issue_id: state_key.to_string(),
-            success,
-            error,
-            completed_at: Utc::now(),
-            attempts,
-            workflow_id,
-        });
-        if inner.completed.len() > MAX_COMPLETED {
-            let drain_count = inner.completed.len() - MAX_COMPLETED;
-            inner.completed.drain(..drain_count);
+        {
+            let mut inner = self.inner.lock().unwrap();
+            let Some(entry) = inner.running.remove(state_key) else {
+                tracing::warn!(state_key, "mark_worker_done called for unknown session, ignoring");
+                return;
+            };
+            inner.completed.push(CompletedEntry {
+                issue_id: state_key.to_string(),
+                issue: entry.issue,
+                success,
+                error,
+                started_at: entry.session.started_at,
+                completed_at: Utc::now(),
+                status: entry.session.status,
+                events: entry.session.events,
+                attempts: entry.session.attempts.len() as u32,
+                workflow_id: entry.workflow_id,
+            });
+            if inner.completed.len() > MAX_COMPLETED {
+                let drain_count = inner.completed.len() - MAX_COMPLETED;
+                inner.completed.drain(..drain_count);
+            }
         }
+        self.persist_completed();
     }
 
     pub fn mark_retry_ready(&self, state_key: &str) {
@@ -314,7 +376,29 @@ impl OrchestratorState {
     }
 
     pub fn get_issue_detail(&self, state_key: &str) -> Option<RunningEntry> {
-        self.inner.lock().unwrap().running.get(state_key).cloned()
+        let inner = self.inner.lock().unwrap();
+        if let Some(entry) = inner.running.get(state_key) {
+            return Some(entry.clone());
+        }
+        // Fall back to completed entries for historical log viewing.
+        inner
+            .completed
+            .iter()
+            .find(|e| e.issue_id == state_key)
+            .map(|e| RunningEntry {
+                issue: e.issue.clone(),
+                session: LiveSession {
+                    issue_id: e.issue_id.clone(),
+                    thread_id: None,
+                    status: e.status.clone(),
+                    started_at: e.started_at,
+                    last_activity: e.completed_at,
+                    attempts: Vec::new(),
+                    events: e.events.clone(),
+                },
+                stall_timeout: Duration::ZERO,
+                workflow_id: e.workflow_id.clone(),
+            })
     }
 
     /// Find sessions with no activity within their per-entry stall timeout.

--- a/src/server/dashboard.rs
+++ b/src/server/dashboard.rs
@@ -76,9 +76,10 @@ pub fn render(snapshot: &StateSnapshot) -> String {
         .iter()
         .map(|entry| {
             format!(
-                "<tr><td><span class=\"workflow-badge\">{}</span></td><td>{}</td><td>{}</td><td>{}</td><td>{}</td></tr>",
+                "<tr><td><span class=\"workflow-badge\">{}</span></td><td><a href=\"/issue/{}\">{}</a></td><td>{}</td><td>{}</td><td>{}</td></tr>",
                 html_escape(&entry.workflow_id),
                 html_escape(&entry.issue_id),
+                html_escape(&entry.issue.identifier),
                 if entry.success { "&#10003; Success" } else { "&#10007; Failed" },
                 entry.attempts,
                 entry.completed_at.format("%H:%M:%S")
@@ -146,23 +147,59 @@ pub fn render(snapshot: &StateSnapshot) -> String {
 
 /// Render a detail page for a specific issue.
 pub fn render_issue_detail(snapshot: &StateSnapshot, issue_id: &str) -> String {
-    let entry = snapshot
+    // Check running sessions first, then completed sessions.
+    let running_entry = snapshot
         .running
         .iter()
         .find(|e| e.session.issue_id == issue_id || e.issue.identifier == issue_id);
 
-    let Some(entry) = entry else {
-        return format!(
-            r#"<!DOCTYPE html>
-<html><head><title>Not Found</title><meta charset="utf-8"><style>{STYLE}</style></head>
-<body><h1><a href="/">← Symposium</a></h1><div class="empty">Issue {} not found in running sessions</div></body></html>"#,
-            html_escape(issue_id),
-        );
-    };
+    let completed_entry = snapshot.completed.iter().find(|e| {
+        e.issue_id == issue_id || e.issue.identifier == issue_id
+    });
 
-    let events_html: String = entry
-        .session
-        .events
+    let is_completed = running_entry.is_none() && completed_entry.is_some();
+
+    // Unify into common variables for the template.
+    let (issue, workflow_id, status, started, last_activity, events_source) =
+        if let Some(entry) = running_entry {
+            (
+                &entry.issue,
+                &entry.workflow_id,
+                format!("{:?}", entry.session.status),
+                entry.session.started_at,
+                entry.session.last_activity,
+                entry.session.events.as_slice(),
+            )
+        } else if let Some(entry) = completed_entry {
+            (
+                &entry.issue,
+                &entry.workflow_id,
+                if entry.success {
+                    "Completed".to_string()
+                } else {
+                    format!(
+                        "Failed{}",
+                        entry
+                            .error
+                            .as_ref()
+                            .map(|e| format!(": {e}"))
+                            .unwrap_or_default()
+                    )
+                },
+                entry.started_at,
+                entry.completed_at,
+                entry.events.as_slice(),
+            )
+        } else {
+            return format!(
+                r#"<!DOCTYPE html>
+<html><head><title>Not Found</title><meta charset="utf-8"><style>{STYLE}</style></head>
+<body><h1><a href="/">← Symposium</a></h1><div class="empty">Issue {} not found</div></body></html>"#,
+                html_escape(issue_id),
+            );
+        };
+
+    let events_html: String = events_source
         .iter()
         .map(|event| {
             let time = event.timestamp.format("%H:%M:%S");
@@ -209,11 +246,27 @@ pub fn render_issue_detail(snapshot: &StateSnapshot, issue_id: &str) -> String {
         })
         .collect();
 
-    let desc = entry
-        .issue
-        .description
-        .as_deref()
-        .unwrap_or("No description");
+    let desc = issue.description.as_deref().unwrap_or("No description");
+
+    // Only auto-reload for running sessions.
+    let reload_script = if is_completed {
+        String::new()
+    } else {
+        r#"<script>
+    (() => {
+        const el = document.querySelector('.events-container');
+        if (!el) return;
+        const wasAtBottom = sessionStorage.getItem('eventsAtBottom') !== 'false';
+        if (wasAtBottom) el.scrollTop = el.scrollHeight;
+        setTimeout(() => {
+            const atBottom = el.scrollHeight - el.scrollTop - el.clientHeight < 50;
+            sessionStorage.setItem('eventsAtBottom', atBottom);
+            location.reload();
+        }, 3000);
+    })();
+    </script>"#
+            .to_string()
+    };
 
     format!(
         r#"<!DOCTYPE html>
@@ -230,7 +283,7 @@ pub fn render_issue_detail(snapshot: &StateSnapshot, issue_id: &str) -> String {
 
     <div class="meta">
         <div class="meta-row"><span class="meta-label">Workflow</span><span class="workflow-badge">{workflow}</span></div>
-        <div class="meta-row"><span class="meta-label">Status</span><span>{status:?}</span></div>
+        <div class="meta-row"><span class="meta-label">Status</span><span>{status}</span></div>
         <div class="meta-row"><span class="meta-label">Priority</span><span>{priority}</span></div>
         <div class="meta-row"><span class="meta-label">Started</span><span>{started}</span></div>
         <div class="meta-row"><span class="meta-label">Last Activity</span><span>{last_activity}</span></div>
@@ -242,33 +295,22 @@ pub fn render_issue_detail(snapshot: &StateSnapshot, issue_id: &str) -> String {
         {events}
     </div>
 
-    <script>
-    (() => {{
-        const el = document.querySelector('.events-container');
-        if (!el) return;
-        const wasAtBottom = sessionStorage.getItem('eventsAtBottom') !== 'false';
-        if (wasAtBottom) el.scrollTop = el.scrollHeight;
-        setTimeout(() => {{
-            const atBottom = el.scrollHeight - el.scrollTop - el.clientHeight < 50;
-            sessionStorage.setItem('eventsAtBottom', atBottom);
-            location.reload();
-        }}, 3000);
-    }})();
-    </script>
+    {reload_script}
 </body>
 </html>"#,
-        id = entry.issue.identifier,
-        title = html_escape(&entry.issue.title),
-        workflow = html_escape(&entry.workflow_id),
-        status = entry.session.status,
-        priority = html_escape(entry.issue.priority.as_deref().unwrap_or("—")),
-        started = entry.session.started_at.format("%H:%M:%S"),
-        last_activity = entry.session.last_activity.format("%H:%M:%S"),
+        id = html_escape(&issue.identifier),
+        title = html_escape(&issue.title),
+        workflow = html_escape(workflow_id),
+        status = html_escape(&status),
+        priority = html_escape(issue.priority.as_deref().unwrap_or("—")),
+        started = started.format("%H:%M:%S"),
+        last_activity = last_activity.format("%H:%M:%S"),
         description = html_escape(desc),
         events = if events_html.is_empty() {
             "<div class=\"empty\">No events yet</div>".to_string()
         } else {
             events_html
         },
+        reload_script = reload_script,
     )
 }


### PR DESCRIPTION
## Summary

- Completed agent sessions now retain their full event logs (up to 200 events) instead of discarding them when transitioning from running to completed
- Session logs are persisted to `completed_sessions.json` on disk and restored on startup
- The dashboard detail page renders completed sessions and completed rows link through to their detail pages

## Details

Previously, `mark_worker_done` removed the `RunningEntry` from the running map and constructed a `CompletedEntry` with only scalar metadata (success/error/attempts). All event data was dropped. The detail page only searched running sessions, so completed sessions returned "not found."

Now:
- `CompletedEntry` carries `issue`, `events`, `started_at`, and `status` from the running entry
- `mark_worker_done` moves these fields through instead of dropping them
- `persist_completed` writes to disk after each completion (following the existing `open_prs.json` pattern)
- `with_persistence` loads completed sessions from disk on startup
- The dashboard detail page falls back to completed sessions, rendered without auto-reload
- Serialization failures log a warning and skip the write instead of overwriting with empty data

## Test plan

- [x] `cargo test` — 81 tests pass
- [x] `cargo clippy` — clean
- [ ] Start the orchestrator, let a session complete, verify the detail page is still viewable
- [ ] Restart the orchestrator, verify completed sessions are restored from disk
- [ ] Verify the dashboard links completed rows to their detail pages