### PR TITLE
Add epic execution with dependency graph and branch stacking

### DIFF
--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -67,6 +67,14 @@ impl Default for SentryConfig {
     }
 }
 
+fn default_base_branch() -> String {
+    "main".to_string()
+}
+
+fn default_property_parent() -> String {
+    "Parent Task".to_string()
+}
+
 fn default_mcp_type() -> String {
     "stdio".to_string()
 }
@@ -106,6 +114,19 @@ pub struct TrackerConfig {
     pub skip_if_set: Option<String>,
     /// Prefix prepended to the raw ID property value (e.g. "BUG-" → "BUG-316205").
     pub id_prefix: Option<String>,
+    /// Filter to only sub-tasks of a specific epic (parent page ID).
+    pub parent_page_id: Option<String>,
+    /// Notion property name for the parent task relation (default: "Parent Task").
+    #[serde(default = "default_property_parent")]
+    pub property_parent: String,
+    /// Notion property name for the task type (e.g. "Type").
+    pub property_type: Option<String>,
+    /// Only dispatch tasks whose type is in this list (e.g. ["Eng", "Feature"]).
+    pub eligible_types: Option<Vec<String>>,
+    /// Status to set on Notion when a PR is created (e.g. "In Review").
+    pub on_pr_created_status: Option<String>,
+    /// Status to set on Notion when a PR is merged (e.g. "Completed").
+    pub on_pr_merged_status: Option<String>,
 }
 
 impl Default for TrackerConfig {
@@ -126,6 +147,12 @@ impl Default for TrackerConfig {
             assignee_user_id: None,
             skip_if_set: None,
             id_prefix: None,
+            parent_page_id: None,
+            property_parent: default_property_parent(),
+            property_type: None,
+            eligible_types: None,
+            on_pr_created_status: None,
+            on_pr_merged_status: None,
         }
     }
 }
@@ -154,6 +181,10 @@ pub struct WorkspaceConfig {
     pub root: String,
     /// Subdirectory within the workspace to use as the agent's working directory.
     pub agent_subdirectory: Option<String>,
+    /// Default base branch for PRs (default: "main"). Used by epic dispatch
+    /// when tasks have no upstream dependencies or for fan-in tasks.
+    #[serde(default = "default_base_branch")]
+    pub default_branch: String,
 }
 
 impl Default for WorkspaceConfig {
@@ -161,6 +192,7 @@ impl Default for WorkspaceConfig {
         Self {
             root: "~/symposium_workspaces".to_string(),
             agent_subdirectory: None,
+            default_branch: default_base_branch(),
         }
     }
 }

--- a/src/domain/epic.rs
+++ b/src/domain/epic.rs
@@ -1,0 +1,608 @@
+use crate::domain::issue::Issue;
+use std::collections::{HashMap, HashSet};
+
+/// State of a task in the epic dependency graph.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum TaskState {
+    /// Not started yet (e.g. "New", "To Do").
+    NotStarted,
+    /// Agent session is currently running.
+    InProgress,
+    /// PR has been created; branch name is known.
+    HasPr(String),
+    /// Terminal success state in Notion.
+    Completed,
+    /// Terminal cancelled/archived state.
+    Cancelled,
+}
+
+/// Result of checking whether a task is eligible to be dispatched.
+#[derive(Debug, Clone)]
+pub struct EpicEligibility {
+    /// Whether the task can be dispatched now.
+    pub eligible: bool,
+    /// The git base branch for this task's work.
+    /// "main" for root tasks or fan-in tasks; a specific branch for stacked tasks.
+    pub base_branch: String,
+    /// Upstream blocker task identifiers that are still pending.
+    pub unresolved: Vec<String>,
+}
+
+/// A dependency graph for an epic's sub-tasks.
+///
+/// Built from two sources:
+/// 1. A Mermaid `graph TD` diagram on the epic page (authoritative)
+/// 2. `Blocked by` native relations on individual tasks (supplementary)
+///
+/// Edges map: downstream_task → set of upstream_tasks that must resolve first.
+#[derive(Debug, Clone, Default)]
+pub struct EpicGraph {
+    /// task_identifier → set of upstream task_identifiers that must complete first
+    pub dependencies: HashMap<String, HashSet<String>>,
+}
+
+impl EpicGraph {
+    /// Parse a Mermaid `graph TD` block and match node labels to task identifiers.
+    ///
+    /// Expected format:
+    /// ```text
+    /// graph TD
+    ///   A["PM: Define requirements"]
+    ///   B["Backend API endpoints"]
+    ///   A --> B
+    ///   A --> C
+    /// ```
+    ///
+    /// Node labels are matched to task titles via normalized substring matching.
+    pub fn from_mermaid(mermaid: &str, tasks: &[Issue]) -> Self {
+        let mut graph = Self::default();
+
+        // 1. Parse node definitions: ID["Label"] or ID["Label"]:::className
+        let mut node_labels: HashMap<String, String> = HashMap::new();
+        let node_re = regex::Regex::new(r#"(\w+)\["([^"]+)"\]"#).expect("valid regex");
+        for cap in node_re.captures_iter(mermaid) {
+            let node_id = cap[1].to_string();
+            let label = cap[2].to_string();
+            node_labels.insert(node_id, label);
+        }
+
+        // 2. Build label → task identifier mapping via normalized substring matching
+        let label_to_task: HashMap<&str, &str> = node_labels
+            .iter()
+            .filter_map(|(node_id, label)| {
+                match match_label_to_task(label, tasks) {
+                    Some(task_id) => Some((label.as_str(), task_id)),
+                    None => {
+                        tracing::warn!(
+                            node_id,
+                            label,
+                            "mermaid node label did not match any task title — \
+                             this node and its edges will be missing from the dependency graph"
+                        );
+                        None
+                    }
+                }
+            })
+            .collect();
+
+        // Also build node_id → task_identifier for edge resolution
+        let node_to_task: HashMap<&str, &str> = node_labels
+            .iter()
+            .filter_map(|(node_id, label)| {
+                let task_id = label_to_task.get(label.as_str())?;
+                Some((node_id.as_str(), *task_id))
+            })
+            .collect();
+
+        // 3. Parse edges: A --> B means A must complete before B starts.
+        // Only match lines that look like standalone edges (not inside label strings).
+        // We require the edge to be at the start of a line (after optional whitespace).
+        let edge_re =
+            regex::Regex::new(r"(?m)^\s*(\w+)\s*-->\s*(\w+)").expect("valid regex");
+        for cap in edge_re.captures_iter(mermaid) {
+            let from = &cap[1];
+            let to = &cap[2];
+            match (node_to_task.get(from), node_to_task.get(to)) {
+                (Some(&upstream), Some(&downstream)) => {
+                    graph
+                        .dependencies
+                        .entry(downstream.to_string())
+                        .or_default()
+                        .insert(upstream.to_string());
+                }
+                _ => {
+                    tracing::warn!(
+                        from,
+                        to,
+                        "mermaid edge references unresolved node(s) — edge skipped"
+                    );
+                }
+            }
+        }
+
+        // Ensure all tasks have entries (even with no dependencies)
+        for task in tasks {
+            graph
+                .dependencies
+                .entry(task.identifier.clone())
+                .or_default();
+        }
+
+        graph
+    }
+
+    /// Merge additional dependency edges from Notion "Blocked by" relations.
+    pub fn merge_blocked_by(&mut self, task_id: &str, blocker_ids: &[String]) {
+        let deps = self.dependencies.entry(task_id.to_string()).or_default();
+        for blocker in blocker_ids {
+            deps.insert(blocker.clone());
+        }
+    }
+
+    /// Get upstream dependencies for a task.
+    pub fn blockers(&self, task_id: &str) -> HashSet<String> {
+        self.dependencies
+            .get(task_id)
+            .cloned()
+            .unwrap_or_default()
+    }
+
+    /// Check if a task is eligible to be dispatched given current task states.
+    ///
+    /// Branch stacking rules:
+    /// - 0 unresolved blockers → eligible, base_branch = default_branch
+    /// - 1 blocker resolved with PR → eligible, base_branch = blocker's branch (stacking)
+    /// - N blockers all resolved → eligible, base_branch = default_branch (fan-in)
+    /// - Any blocker not resolved → not eligible
+    pub fn check_eligibility(
+        &self,
+        task_id: &str,
+        task_states: &HashMap<String, TaskState>,
+        default_branch: &str,
+    ) -> EpicEligibility {
+        let deps = self.blockers(task_id);
+
+        if deps.is_empty() {
+            return EpicEligibility {
+                eligible: true,
+                base_branch: default_branch.to_string(),
+                unresolved: vec![],
+            };
+        }
+
+        let mut unresolved = Vec::new();
+        let mut resolved_branches: Vec<String> = Vec::new();
+
+        for dep_id in &deps {
+            match task_states.get(dep_id) {
+                Some(TaskState::Completed | TaskState::Cancelled) => {
+                    // Fully resolved, no branch to stack on.
+                    // Cancelled tasks are treated as resolved — if a blocker is cancelled,
+                    // the downstream task is unblocked (the assumption is that the cancelled
+                    // work is no longer needed, not that the epic is abandoned).
+                }
+                Some(TaskState::HasPr(branch)) => {
+                    resolved_branches.push(branch.clone());
+                }
+                _ => {
+                    // NotStarted, InProgress, or unknown — not resolved
+                    unresolved.push(dep_id.clone());
+                }
+            }
+        }
+
+        if !unresolved.is_empty() {
+            return EpicEligibility {
+                eligible: false,
+                base_branch: default_branch.to_string(),
+                unresolved,
+            };
+        }
+
+        // All blockers are resolved
+        let base_branch = if resolved_branches.len() == 1 {
+            // Single blocker with PR → stack on it
+            resolved_branches.into_iter().next().unwrap()
+        } else {
+            // 0 PR branches (all completed/cancelled) or fan-in (multiple PRs)
+            default_branch.to_string()
+        };
+
+        EpicEligibility {
+            eligible: true,
+            base_branch,
+            unresolved: vec![],
+        }
+    }
+}
+
+/// Extract a Mermaid code block from page content (fenced with ```mermaid).
+pub fn extract_mermaid_block(content: &str) -> Option<&str> {
+    let start_marker = "```mermaid";
+    let start = content.find(start_marker)?;
+    let block_start = start + start_marker.len();
+    let end = content[block_start..].find("```")?;
+    Some(content[block_start..block_start + end].trim())
+}
+
+/// Match a Mermaid node label to a task identifier via normalized substring matching.
+///
+/// Normalizes both the label and task titles to lowercase, strips common prefixes
+/// like "[iOS]", "[Backend]", and compares.
+fn match_label_to_task<'a>(label: &str, tasks: &'a [Issue]) -> Option<&'a str> {
+    let normalized_label = normalize_for_matching(label);
+
+    // Try exact normalized match first
+    for task in tasks {
+        let normalized_title = normalize_for_matching(&task.title);
+        if normalized_label == normalized_title {
+            return Some(&task.identifier);
+        }
+    }
+
+    // Try substring match: label contained in title or title contained in label
+    let mut best_match: Option<(&str, usize)> = None;
+    for task in tasks {
+        let normalized_title = normalize_for_matching(&task.title);
+        let score = if normalized_title.contains(&normalized_label) {
+            // Label is a substring of the title — shorter difference = better match
+            normalized_title.len() - normalized_label.len()
+        } else if normalized_label.contains(&normalized_title) {
+            normalized_label.len() - normalized_title.len()
+        } else {
+            continue;
+        };
+
+        if best_match.is_none() || score < best_match.unwrap().1 {
+            best_match = Some((&task.identifier, score));
+        }
+    }
+
+    best_match.map(|(id, _)| id)
+}
+
+/// Normalize a string for fuzzy matching: lowercase, strip tag prefixes, collapse whitespace.
+fn normalize_for_matching(s: &str) -> String {
+    // Strip common tag prefixes like [iOS], [Backend], [All]
+    let tag_re = regex::Regex::new(r"\[[\w\s]+\]\s*").expect("valid regex");
+    let stripped = tag_re.replace_all(s, "");
+    stripped.to_lowercase().split_whitespace().collect::<Vec<_>>().join(" ")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+
+    fn make_task(id: &str, title: &str) -> Issue {
+        Issue {
+            identifier: id.to_string(),
+            title: title.to_string(),
+            description: None,
+            status: "New".to_string(),
+            priority: None,
+            url: None,
+            notion_page_id: None,
+            blockers: vec![],
+            source: "notion".to_string(),
+            extra: HashMap::new(),
+            comments: vec![],
+            workflow_id: String::new(),
+        }
+    }
+
+    #[test]
+    fn parse_simple_mermaid_graph() {
+        let tasks = vec![
+            make_task("TASK-1", "Define requirements"),
+            make_task("TASK-2", "Backend API"),
+            make_task("TASK-3", "iOS Gate"),
+        ];
+
+        let mermaid = r#"graph TD
+    A["Define requirements"]
+    B["Backend API"]
+    C["iOS Gate"]
+    A --> B
+    A --> C"#;
+
+        let graph = EpicGraph::from_mermaid(mermaid, &tasks);
+
+        assert!(graph.blockers("TASK-1").is_empty());
+        assert_eq!(
+            graph.blockers("TASK-2"),
+            HashSet::from(["TASK-1".to_string()])
+        );
+        assert_eq!(
+            graph.blockers("TASK-3"),
+            HashSet::from(["TASK-1".to_string()])
+        );
+    }
+
+    #[test]
+    fn parse_superarchive_style_mermaid() {
+        let tasks = vec![
+            make_task("TASK-1", "[PM] Define super-archive requirements"),
+            make_task("TASK-2", "[Backend] API endpoints for archive"),
+            make_task("TASK-3", "[iOS] Gate: swipe gesture framework"),
+            make_task("TASK-4", "[iOS] Swipe action UI components"),
+            make_task("TASK-5", "[Backend] GraphQL codegen"),
+            make_task("TASK-6", "[iOS] Pending carousel"),
+            make_task("TASK-7", "[All] End-to-end wiring"),
+        ];
+
+        let mermaid = r#"graph TD
+    PM["Define super-archive requirements"]
+    BE["API endpoints for archive"]
+    GATE["Gate: swipe gesture framework"]
+    SWIPE["Swipe action UI components"]
+    GQL["GraphQL codegen"]
+    PEND["Pending carousel"]
+    E2E["End-to-end wiring"]
+    PM --> BE
+    PM --> GATE
+    GATE --> SWIPE
+    BE --> GQL
+    GATE --> PEND
+    GQL --> PEND
+    SWIPE --> E2E
+    PEND --> E2E
+    GQL --> E2E
+    BE --> E2E"#;
+
+        let graph = EpicGraph::from_mermaid(mermaid, &tasks);
+
+        // PM has no deps
+        assert!(graph.blockers("TASK-1").is_empty());
+
+        // Backend API depends on PM
+        assert_eq!(
+            graph.blockers("TASK-2"),
+            HashSet::from(["TASK-1".to_string()])
+        );
+
+        // iOS Gate depends on PM
+        assert_eq!(
+            graph.blockers("TASK-3"),
+            HashSet::from(["TASK-1".to_string()])
+        );
+
+        // Swipe depends on iOS Gate
+        assert_eq!(
+            graph.blockers("TASK-4"),
+            HashSet::from(["TASK-3".to_string()])
+        );
+
+        // GraphQL depends on Backend API
+        assert_eq!(
+            graph.blockers("TASK-5"),
+            HashSet::from(["TASK-2".to_string()])
+        );
+
+        // Pending carousel depends on iOS Gate + GraphQL
+        assert_eq!(
+            graph.blockers("TASK-6"),
+            HashSet::from(["TASK-3".to_string(), "TASK-5".to_string()])
+        );
+
+        // E2E depends on Swipe + Pending + GraphQL + Backend
+        assert_eq!(
+            graph.blockers("TASK-7"),
+            HashSet::from([
+                "TASK-4".to_string(),
+                "TASK-6".to_string(),
+                "TASK-5".to_string(),
+                "TASK-2".to_string(),
+            ])
+        );
+    }
+
+    #[test]
+    fn merge_blocked_by_adds_edges() {
+        let tasks = vec![
+            make_task("TASK-1", "First"),
+            make_task("TASK-2", "Second"),
+            make_task("TASK-3", "Third"),
+        ];
+
+        let mermaid = r#"graph TD
+    A["First"]
+    B["Second"]
+    C["Third"]
+    A --> B"#;
+
+        let mut graph = EpicGraph::from_mermaid(mermaid, &tasks);
+        // Mermaid only has A→B, add A→C from Blocked by relation
+        graph.merge_blocked_by("TASK-3", &["TASK-1".to_string()]);
+
+        assert_eq!(
+            graph.blockers("TASK-3"),
+            HashSet::from(["TASK-1".to_string()])
+        );
+    }
+
+    #[test]
+    fn eligibility_no_blockers() {
+        let graph = EpicGraph {
+            dependencies: HashMap::from([("TASK-1".to_string(), HashSet::new())]),
+        };
+
+        let states = HashMap::new();
+        let result = graph.check_eligibility("TASK-1", &states, "main");
+        assert!(result.eligible);
+        assert_eq!(result.base_branch, "main");
+        assert!(result.unresolved.is_empty());
+    }
+
+    #[test]
+    fn eligibility_single_blocker_completed() {
+        let graph = EpicGraph {
+            dependencies: HashMap::from([(
+                "TASK-2".to_string(),
+                HashSet::from(["TASK-1".to_string()]),
+            )]),
+        };
+
+        let states = HashMap::from([("TASK-1".to_string(), TaskState::Completed)]);
+        let result = graph.check_eligibility("TASK-2", &states, "main");
+        assert!(result.eligible);
+        assert_eq!(result.base_branch, "main");
+    }
+
+    #[test]
+    fn eligibility_single_blocker_has_pr_stacks() {
+        let graph = EpicGraph {
+            dependencies: HashMap::from([(
+                "TASK-2".to_string(),
+                HashSet::from(["TASK-1".to_string()]),
+            )]),
+        };
+
+        let states = HashMap::from([(
+            "TASK-1".to_string(),
+            TaskState::HasPr("symposium/task-TASK-1".to_string()),
+        )]);
+        let result = graph.check_eligibility("TASK-2", &states, "main");
+        assert!(result.eligible);
+        assert_eq!(result.base_branch, "symposium/task-TASK-1");
+    }
+
+    #[test]
+    fn eligibility_fan_in_multiple_prs() {
+        let graph = EpicGraph {
+            dependencies: HashMap::from([(
+                "TASK-3".to_string(),
+                HashSet::from(["TASK-1".to_string(), "TASK-2".to_string()]),
+            )]),
+        };
+
+        let states = HashMap::from([
+            (
+                "TASK-1".to_string(),
+                TaskState::HasPr("symposium/task-TASK-1".to_string()),
+            ),
+            (
+                "TASK-2".to_string(),
+                TaskState::HasPr("symposium/task-TASK-2".to_string()),
+            ),
+        ]);
+        let result = graph.check_eligibility("TASK-3", &states, "main");
+        assert!(result.eligible);
+        // Fan-in: base off main since we can't stack on multiple branches
+        assert_eq!(result.base_branch, "main");
+    }
+
+    #[test]
+    fn eligibility_blocked_by_unresolved() {
+        let graph = EpicGraph {
+            dependencies: HashMap::from([(
+                "TASK-2".to_string(),
+                HashSet::from(["TASK-1".to_string()]),
+            )]),
+        };
+
+        let states = HashMap::from([("TASK-1".to_string(), TaskState::NotStarted)]);
+        let result = graph.check_eligibility("TASK-2", &states, "main");
+        assert!(!result.eligible);
+        assert_eq!(result.unresolved, vec!["TASK-1".to_string()]);
+    }
+
+    #[test]
+    fn eligibility_mixed_resolved_and_unresolved() {
+        let graph = EpicGraph {
+            dependencies: HashMap::from([(
+                "TASK-3".to_string(),
+                HashSet::from(["TASK-1".to_string(), "TASK-2".to_string()]),
+            )]),
+        };
+
+        let states = HashMap::from([
+            (
+                "TASK-1".to_string(),
+                TaskState::HasPr("symposium/task-TASK-1".to_string()),
+            ),
+            ("TASK-2".to_string(), TaskState::InProgress),
+        ]);
+        let result = graph.check_eligibility("TASK-3", &states, "main");
+        assert!(!result.eligible);
+        assert_eq!(result.unresolved, vec!["TASK-2".to_string()]);
+    }
+
+    #[test]
+    fn eligibility_blocker_cancelled_unblocks_downstream() {
+        let graph = EpicGraph {
+            dependencies: HashMap::from([(
+                "TASK-2".to_string(),
+                HashSet::from(["TASK-1".to_string()]),
+            )]),
+        };
+
+        let states = HashMap::from([("TASK-1".to_string(), TaskState::Cancelled)]);
+        let result = graph.check_eligibility("TASK-2", &states, "main");
+        assert!(result.eligible);
+        assert_eq!(result.base_branch, "main");
+    }
+
+    #[test]
+    fn eligibility_unknown_task_treated_as_no_deps() {
+        let graph = EpicGraph::default();
+        let states = HashMap::new();
+        let result = graph.check_eligibility("TASK-UNKNOWN", &states, "main");
+        assert!(result.eligible);
+        assert_eq!(result.base_branch, "main");
+    }
+
+    #[test]
+    fn extract_mermaid_from_content() {
+        let content = r#"# Epic: Super-archive
+
+Some description here.
+
+```mermaid
+graph TD
+    A["Task 1"]
+    B["Task 2"]
+    A --> B
+```
+
+More text after.
+"#;
+        let block = extract_mermaid_block(content).unwrap();
+        assert!(block.contains("graph TD"));
+        assert!(block.contains("A --> B"));
+    }
+
+    #[test]
+    fn extract_mermaid_missing() {
+        assert!(extract_mermaid_block("no mermaid here").is_none());
+    }
+
+    #[test]
+    fn normalize_strips_tags() {
+        assert_eq!(
+            normalize_for_matching("[iOS] Gate: swipe gesture framework"),
+            "gate: swipe gesture framework"
+        );
+        assert_eq!(
+            normalize_for_matching("[Backend] API endpoints"),
+            "api endpoints"
+        );
+    }
+
+    #[test]
+    fn match_label_to_task_with_tags() {
+        let tasks = vec![
+            make_task("TASK-1", "[iOS] Gate: swipe gesture framework"),
+            make_task("TASK-2", "[Backend] API endpoints"),
+        ];
+
+        assert_eq!(
+            match_label_to_task("Gate: swipe gesture framework", &tasks),
+            Some("TASK-1")
+        );
+        assert_eq!(
+            match_label_to_task("API endpoints", &tasks),
+            Some("TASK-2")
+        );
+    }
+}

--- a/src/domain/mod.rs
+++ b/src/domain/mod.rs
@@ -1,3 +1,4 @@
+pub mod epic;
 pub mod issue;
 pub mod retry;
 pub mod session;

--- a/src/domain/state.rs
+++ b/src/domain/state.rs
@@ -1,3 +1,4 @@
+use super::epic::EpicGraph;
 use super::issue::Issue;
 use super::retry::RetryEntry;
 use super::session::{AgentEvent, LiveSession, RunStatus};
@@ -23,6 +24,7 @@ struct StateInner {
     tokens: TokenTotals,
     open_prs: HashMap<String, OpenPr>,
     state_dir: Option<PathBuf>,
+    epic_graph: Option<EpicGraph>,
 }
 
 /// A PR opened by Symposium that is being monitored for review feedback.
@@ -33,6 +35,9 @@ pub struct OpenPr {
     pub workspace_dir: PathBuf,
     pub last_addressed_at: Option<DateTime<Utc>>,
     pub workflow_id: String,
+    /// The git branch name for this PR (e.g. "symposium/task-TASK-123456").
+    #[serde(default)]
+    pub branch_name: String,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -85,6 +90,7 @@ impl OrchestratorState {
                 tokens: TokenTotals::default(),
                 open_prs: HashMap::new(),
                 state_dir: None,
+                epic_graph: None,
             })),
         }
     }
@@ -108,6 +114,7 @@ impl OrchestratorState {
                 tokens: TokenTotals::default(),
                 open_prs,
                 state_dir: Some(state_dir),
+                epic_graph: None,
             })),
         }
     }
@@ -328,7 +335,15 @@ impl OrchestratorState {
     }
 
 
-    pub fn track_pr(&self, state_key: &str, issue: Issue, pr_number: u64, workspace_dir: PathBuf, workflow_id: &str) {
+    pub fn track_pr(
+        &self,
+        state_key: &str,
+        issue: Issue,
+        pr_number: u64,
+        workspace_dir: PathBuf,
+        workflow_id: &str,
+        branch_name: &str,
+    ) {
         self.inner.lock().unwrap().open_prs.insert(
             state_key.to_string(),
             OpenPr {
@@ -337,6 +352,7 @@ impl OrchestratorState {
                 workspace_dir,
                 last_addressed_at: None,
                 workflow_id: workflow_id.to_string(),
+                branch_name: branch_name.to_string(),
             },
         );
         self.persist_open_prs();
@@ -399,6 +415,16 @@ impl OrchestratorState {
                 stall_timeout: Duration::ZERO,
                 workflow_id: e.workflow_id.clone(),
             })
+    }
+
+    /// Store the epic dependency graph.
+    pub fn set_epic_graph(&self, graph: EpicGraph) {
+        self.inner.lock().unwrap().epic_graph = Some(graph);
+    }
+
+    /// Get a clone of the epic graph, if set.
+    pub fn epic_graph(&self) -> Option<EpicGraph> {
+        self.inner.lock().unwrap().epic_graph.clone()
     }
 
     /// Find sessions with no activity within their per-entry stall timeout.

--- a/src/orchestrator/dispatch.rs
+++ b/src/orchestrator/dispatch.rs
@@ -1,9 +1,87 @@
 use crate::config::schema::ServiceConfig;
+use crate::domain::epic::EpicGraph;
 use crate::domain::issue::Issue;
 use crate::domain::state::OrchestratorState;
 use crate::domain::workflow::WorkflowId;
 
+/// Result of eligibility check, including epic-aware base_branch.
+#[derive(Debug, Clone)]
+pub struct DispatchDecision {
+    pub eligible: bool,
+    pub base_branch: String,
+}
+
 /// Check if an issue is eligible to be dispatched.
+/// Returns a `DispatchDecision` with eligibility and the base branch for epic workflows.
+pub fn check_eligible(
+    issue: &Issue,
+    state: &OrchestratorState,
+    config: &ServiceConfig,
+    workflow_id: &WorkflowId,
+    global_max_agents: Option<usize>,
+    epic_graph: Option<&EpicGraph>,
+) -> DispatchDecision {
+    let default_branch = &config.workspace.default_branch;
+    let state_key = workflow_id.state_key(&issue.identifier);
+    let not_eligible = DispatchDecision {
+        eligible: false,
+        base_branch: default_branch.clone(),
+    };
+
+    // Not already running
+    if state.is_running(&state_key) {
+        return not_eligible;
+    }
+    // Not in retry backoff (unless ready)
+    if state.is_in_retry(&state_key) {
+        return not_eligible;
+    }
+    // Not already completed successfully
+    if state.is_completed_successfully(&state_key) {
+        return not_eligible;
+    }
+    // Under per-workflow concurrency limit
+    if state.running_count_for_workflow(&workflow_id.0) >= config.agent.max_concurrent_agents {
+        return not_eligible;
+    }
+    // Under global concurrency limit (if set)
+    if let Some(global_max) = global_max_agents
+        && state.running_count() >= global_max
+    {
+        return not_eligible;
+    }
+
+    // Check blockers via epic graph if available, otherwise fall back to issue.blockers
+    if let Some(graph) = epic_graph {
+        let task_states = build_task_states(state, workflow_id);
+        let eligibility =
+            graph.check_eligibility(&issue.identifier, &task_states, default_branch);
+        if !eligibility.eligible {
+            tracing::debug!(
+                issue_id = issue.identifier,
+                unresolved = ?eligibility.unresolved,
+                "epic: blocked by unresolved dependencies"
+            );
+            return not_eligible;
+        }
+        return DispatchDecision {
+            eligible: true,
+            base_branch: eligibility.base_branch,
+        };
+    }
+
+    // No epic graph — use legacy blocker check
+    if !issue.blockers.is_empty() {
+        return not_eligible;
+    }
+
+    DispatchDecision {
+        eligible: true,
+        base_branch: default_branch.clone(),
+    }
+}
+
+/// Backward-compatible wrapper for callers that don't need DispatchDecision.
 pub fn is_eligible(
     issue: &Issue,
     state: &OrchestratorState,
@@ -11,35 +89,55 @@ pub fn is_eligible(
     workflow_id: &WorkflowId,
     global_max_agents: Option<usize>,
 ) -> bool {
-    let state_key = workflow_id.state_key(&issue.identifier);
+    check_eligible(issue, state, config, workflow_id, global_max_agents, None).eligible
+}
 
-    // Not already running
-    if state.is_running(&state_key) {
-        return false;
+/// Build a map of task_identifier → TaskState from orchestrator state.
+///
+/// Filters to the given workflow so that identifiers from other workflows
+/// don't leak into the epic dependency graph.
+///
+/// Priority ordering: HasPr > Completed > InProgress. A task with a tracked
+/// PR is always reported as HasPr, even if a review worker is running on it.
+fn build_task_states(
+    state: &OrchestratorState,
+    workflow_id: &WorkflowId,
+) -> std::collections::HashMap<String, crate::domain::epic::TaskState> {
+    use crate::domain::epic::TaskState;
+    let mut task_states = std::collections::HashMap::new();
+
+    // Snapshot everything under one lock to avoid state drift between calls.
+    let snapshot = state.snapshot();
+
+    // Tasks with open PRs → HasPr with branch name (highest priority)
+    for pr in &snapshot.open_prs {
+        if pr.workflow_id == workflow_id.0 {
+            task_states.insert(
+                pr.issue.identifier.clone(),
+                TaskState::HasPr(pr.branch_name.clone()),
+            );
+        }
     }
-    // Not in retry backoff (unless ready)
-    if state.is_in_retry(&state_key) {
-        return false;
+
+    // Completed tasks (won't overwrite HasPr)
+    for entry in &snapshot.completed {
+        if entry.workflow_id == workflow_id.0 && entry.success {
+            task_states
+                .entry(entry.issue.identifier.clone())
+                .or_insert(TaskState::Completed);
+        }
     }
-    // Not already completed successfully
-    if state.is_completed_successfully(&state_key) {
-        return false;
+
+    // Running tasks (won't overwrite HasPr or Completed)
+    for entry in &snapshot.running {
+        if entry.workflow_id == workflow_id.0 {
+            task_states
+                .entry(entry.issue.identifier.clone())
+                .or_insert(TaskState::InProgress);
+        }
     }
-    // Under per-workflow concurrency limit
-    if state.running_count_for_workflow(&workflow_id.0) >= config.agent.max_concurrent_agents {
-        return false;
-    }
-    // Under global concurrency limit (if set)
-    if let Some(global_max) = global_max_agents
-        && state.running_count() >= global_max
-    {
-        return false;
-    }
-    // Has no unresolved blockers
-    if !issue.blockers.is_empty() {
-        return false;
-    }
-    true
+
+    task_states
 }
 
 /// Sort candidate issues by priority (higher priority first).
@@ -172,5 +270,188 @@ mod tests {
         assert_eq!(state.running_count_for_workflow("bugs"), 2);
         assert_eq!(state.running_count_for_workflow("sentry"), 1);
         assert_eq!(state.running_count(), 3);
+    }
+
+    #[test]
+    fn build_task_states_running() {
+        let state = OrchestratorState::new();
+        let wf = WorkflowId("epic".to_string());
+        state.start_session(
+            &wf.state_key("TASK-1"),
+            test_issue("TASK-1"),
+            Duration::from_secs(300),
+            "epic",
+        );
+
+        let ts = build_task_states(&state, &wf);
+        assert_eq!(
+            ts.get("TASK-1"),
+            Some(&crate::domain::epic::TaskState::InProgress)
+        );
+    }
+
+    #[test]
+    fn build_task_states_has_pr() {
+        let state = OrchestratorState::new();
+        let wf = WorkflowId("epic".to_string());
+        state.track_pr(
+            &wf.state_key("TASK-1"),
+            test_issue("TASK-1"),
+            42,
+            "/tmp".into(),
+            "epic",
+            "symposium/task-TASK-1",
+        );
+
+        let ts = build_task_states(&state, &wf);
+        assert_eq!(
+            ts.get("TASK-1"),
+            Some(&crate::domain::epic::TaskState::HasPr(
+                "symposium/task-TASK-1".to_string()
+            ))
+        );
+    }
+
+    #[test]
+    fn build_task_states_completed() {
+        let state = OrchestratorState::new();
+        let wf = WorkflowId("epic".to_string());
+
+        // Start and complete a session
+        state.start_session(
+            &wf.state_key("TASK-1"),
+            test_issue("TASK-1"),
+            Duration::from_secs(300),
+            "epic",
+        );
+        state.mark_worker_done(&wf.state_key("TASK-1"), true, None);
+
+        let ts = build_task_states(&state, &wf);
+        assert_eq!(
+            ts.get("TASK-1"),
+            Some(&crate::domain::epic::TaskState::Completed)
+        );
+    }
+
+    #[test]
+    fn build_task_states_has_pr_takes_priority_over_completed() {
+        let state = OrchestratorState::new();
+        let wf = WorkflowId("epic".to_string());
+
+        // Task completed successfully AND has a tracked PR
+        state.start_session(
+            &wf.state_key("TASK-1"),
+            test_issue("TASK-1"),
+            Duration::from_secs(300),
+            "epic",
+        );
+        state.mark_worker_done(&wf.state_key("TASK-1"), true, None);
+        state.track_pr(
+            &wf.state_key("TASK-1"),
+            test_issue("TASK-1"),
+            42,
+            "/tmp".into(),
+            "epic",
+            "symposium/task-TASK-1",
+        );
+
+        let ts = build_task_states(&state, &wf);
+        // HasPr should take priority — downstream tasks can stack on this branch
+        assert_eq!(
+            ts.get("TASK-1"),
+            Some(&crate::domain::epic::TaskState::HasPr(
+                "symposium/task-TASK-1".to_string()
+            ))
+        );
+    }
+
+    #[test]
+    fn build_task_states_filters_by_workflow() {
+        let state = OrchestratorState::new();
+        let wf_a = WorkflowId("epic-a".to_string());
+        let wf_b = WorkflowId("epic-b".to_string());
+
+        state.start_session(
+            &wf_a.state_key("TASK-1"),
+            test_issue("TASK-1"),
+            Duration::from_secs(300),
+            "epic-a",
+        );
+        state.track_pr(
+            &wf_b.state_key("TASK-2"),
+            test_issue("TASK-2"),
+            99,
+            "/tmp".into(),
+            "epic-b",
+            "symposium/task-TASK-2",
+        );
+
+        // Workflow A should only see its own running task
+        let ts_a = build_task_states(&state, &wf_a);
+        assert!(ts_a.contains_key("TASK-1"));
+        assert!(!ts_a.contains_key("TASK-2"));
+
+        // Workflow B should only see its own PR
+        let ts_b = build_task_states(&state, &wf_b);
+        assert!(!ts_b.contains_key("TASK-1"));
+        assert!(ts_b.contains_key("TASK-2"));
+    }
+
+    #[test]
+    fn epic_eligible_with_graph() {
+        use crate::domain::epic::EpicGraph;
+        use std::collections::HashSet;
+
+        let state = OrchestratorState::new();
+        let wf = WorkflowId("epic".to_string());
+        let config = test_config(5);
+
+        // Task-2 depends on Task-1; Task-1 has a PR
+        let mut graph = EpicGraph::default();
+        graph
+            .dependencies
+            .insert("TASK-1".to_string(), HashSet::new());
+        graph.dependencies.insert(
+            "TASK-2".to_string(),
+            HashSet::from(["TASK-1".to_string()]),
+        );
+
+        state.track_pr(
+            &wf.state_key("TASK-1"),
+            test_issue("TASK-1"),
+            1,
+            "/tmp".into(),
+            "epic",
+            "symposium/task-TASK-1",
+        );
+
+        let decision =
+            check_eligible(&test_issue("TASK-2"), &state, &config, &wf, None, Some(&graph));
+        assert!(decision.eligible);
+        assert_eq!(decision.base_branch, "symposium/task-TASK-1");
+    }
+
+    #[test]
+    fn epic_blocked_when_dep_not_started() {
+        use crate::domain::epic::EpicGraph;
+        use std::collections::HashSet;
+
+        let state = OrchestratorState::new();
+        let wf = WorkflowId("epic".to_string());
+        let config = test_config(5);
+
+        let mut graph = EpicGraph::default();
+        graph
+            .dependencies
+            .insert("TASK-1".to_string(), HashSet::new());
+        graph.dependencies.insert(
+            "TASK-2".to_string(),
+            HashSet::from(["TASK-1".to_string()]),
+        );
+        // TASK-1 has no state → not resolved
+
+        let decision =
+            check_eligible(&test_issue("TASK-2"), &state, &config, &wf, None, Some(&graph));
+        assert!(!decision.eligible);
     }
 }

--- a/src/orchestrator/pr_review.rs
+++ b/src/orchestrator/pr_review.rs
@@ -79,6 +79,19 @@ pub async fn check_and_dispatch_pr_reviews(
                         state = status.state,
                         "PR reached terminal state, untracking"
                     );
+                    // Update Notion status on merge (e.g. set to "Completed")
+                    if status.state == "MERGED"
+                        && let Some(ref target_status) = config.tracker.on_pr_merged_status
+                        && let Some(ref page_id) = pr.issue.notion_page_id
+                    {
+                        super::tick::update_notion_status(
+                            &config.tracker,
+                            page_id,
+                            &config.tracker.property_status,
+                            target_status,
+                        )
+                        .await;
+                    }
                     state.untrack_pr(&pr_state_key);
                     continue;
                 }
@@ -303,7 +316,9 @@ async fn run_pr_review_worker(
         }),
     );
     let ws = WorkspaceManager::new(config_rx.clone());
-    ws.prepare(&pr.issue, None).await?;
+    // PR review runs on an existing workspace/branch — base_branch is not needed.
+    // The before_run hook should use `git fetch && git rebase` without a base branch ref.
+    ws.prepare(&pr.issue, None, None).await?;
 
     // Build prompt
     let prompt_text = build_pr_review_prompt(
@@ -321,10 +336,11 @@ async fn run_pr_review_worker(
     );
     state.update_session_status(review_state_key, RunStatus::Running);
 
-    let agent_dir = match &config.workspace.agent_subdirectory {
-        Some(sub) => workspace_dir.join(sub),
-        None => workspace_dir.clone(),
-    };
+    let agent_dir = crate::prompt::resolve_agent_dir(
+        workspace_dir,
+        config.workspace.agent_subdirectory.as_deref(),
+        &pr.issue,
+    );
 
     let runner = agent::AgentRunner::new(config.clone());
     let (mut worker, _mcp_guard) = runner
@@ -334,7 +350,7 @@ async fn run_pr_review_worker(
     let success = run_agent_attempt(&mut worker, &prompt_text, state, review_state_key).await?;
 
     // Run after_run hook
-    ws.finish(&pr.issue, success).await?;
+    ws.finish(&pr.issue, success, None).await?;
 
     Ok(success)
 }
@@ -432,6 +448,7 @@ mod tests {
             workspace_dir: "/tmp".into(),
             last_addressed_at: None,
             workflow_id: "default".to_string(),
+            branch_name: String::new(),
         };
         let status = PrStatus {
             state: "OPEN".into(),
@@ -448,6 +465,7 @@ mod tests {
             workspace_dir: "/tmp".into(),
             last_addressed_at: None,
             workflow_id: "default".to_string(),
+            branch_name: String::new(),
         };
         let status = PrStatus {
             state: "OPEN".into(),
@@ -465,6 +483,7 @@ mod tests {
             workspace_dir: "/tmp".into(),
             last_addressed_at: Some(now),
             workflow_id: "default".to_string(),
+            branch_name: String::new(),
         };
         let status = PrStatus {
             state: "OPEN".into(),
@@ -482,6 +501,7 @@ mod tests {
             workspace_dir: "/tmp".into(),
             last_addressed_at: Some(now - chrono::Duration::hours(1)),
             workflow_id: "default".to_string(),
+            branch_name: String::new(),
         };
         let status = PrStatus {
             state: "OPEN".into(),
@@ -644,6 +664,7 @@ mod tests {
             workspace_dir: "/tmp/ws".into(),
             last_addressed_at: None,
             workflow_id: "default".to_string(),
+            branch_name: String::new(),
         };
         let status = PrStatus {
             state,

--- a/src/orchestrator/reconcile.rs
+++ b/src/orchestrator/reconcile.rs
@@ -80,7 +80,7 @@ pub async fn discover_open_prs(state: &OrchestratorState, workflows: &[WorkflowH
             }
 
             // Run gh pr view to check for an open PR
-            let script = "gh pr view --json number,state,title 2>/dev/null";
+            let script = "gh pr view --json number,state,title,headRefName 2>/dev/null";
             let output = match hooks::run_hook_with_output(script, &path, GH_TIMEOUT).await {
                 Ok(o) => o,
                 Err(_) => continue, // no PR on this branch, or gh not available
@@ -120,12 +120,17 @@ pub async fn discover_open_prs(state: &OrchestratorState, workflows: &[WorkflowH
                 workflow_id: wf.id.0.clone(),
             };
 
+            let branch_name = data["headRefName"]
+                .as_str()
+                .unwrap_or("")
+                .to_string();
             state.track_pr(
                 &state_key,
                 issue,
                 pr_number,
                 path,
                 &wf.id.0,
+                &branch_name,
             );
             tracing::info!(
                 workflow = %wf.id,

--- a/src/orchestrator/tick.rs
+++ b/src/orchestrator/tick.rs
@@ -126,16 +126,94 @@ pub async fn run_workflow_tick(
             }
         }
 
-        // 4. Sort by priority and filter eligible
+        // 4. Build epic graph if parent_page_id is set and graph not yet initialized.
+        // Note: the graph is built once and cached for the lifetime of the process.
+        // If tasks are added to the epic or Blocked by relations change after startup,
+        // a restart is required to pick up the changes. New tasks that appear in
+        // candidates but have no graph entry will be treated as having no dependencies.
+        if config.tracker.parent_page_id.is_some()
+            && state.epic_graph().is_none()
+            && let Some(ref mut t) = tracker
+        {
+            match t.fetch_all_epic_tasks().await {
+                Ok(all_tasks) => {
+                    tracing::info!(
+                        workflow = %wf_id,
+                        count = all_tasks.len(),
+                        "fetched all epic sub-tasks for dependency graph"
+                    );
+                    // For now, build graph from Blocked by relations only.
+                    // Mermaid parsing requires fetching the epic page content,
+                    // which can be added later.
+                    let mut graph = crate::domain::epic::EpicGraph::default();
+                    for task in &all_tasks {
+                        graph
+                            .dependencies
+                            .entry(task.identifier.clone())
+                            .or_default();
+                        // Merge Blocked by relation edges from extra properties
+                        if let Some(blocked_by) = task.extra.get("blocked by") {
+                            let blocker_ids: Vec<String> = blocked_by
+                                .split(',')
+                                .map(|s| s.trim().to_string())
+                                .filter(|s| !s.is_empty())
+                                .collect();
+                            graph.merge_blocked_by(&task.identifier, &blocker_ids);
+                        }
+                    }
+                    state.set_epic_graph(graph);
+                }
+                Err(e) => {
+                    tracing::error!(
+                        workflow = %wf_id,
+                        "failed to fetch epic sub-tasks: {e}"
+                    );
+                }
+            }
+        }
+
+        // 4b. Sort by priority and filter eligible
         dispatch::sort_candidates(&mut candidates);
+        let epic_graph = state.epic_graph();
+
+        // Guard: if parent_page_id is configured but the graph isn't available,
+        // skip dispatching to avoid sending all tasks simultaneously without
+        // dependency ordering. The graph will be retried on the next tick.
+        let skip_epic_dispatch =
+            config.tracker.parent_page_id.is_some() && epic_graph.is_none();
+        if skip_epic_dispatch {
+            tracing::warn!(
+                workflow = %wf_id,
+                candidates = candidates.len(),
+                "epic graph not available — skipping dispatch to preserve dependency ordering"
+            );
+        }
 
         // 5. Dispatch eligible issues (up to remaining capacity)
-        for issue in candidates {
-            if !dispatch::is_eligible(&issue, state, &config, wf_id, global_max_agents) {
-                continue;
-            }
+        if !skip_epic_dispatch {
+            for issue in candidates {
+                let decision = dispatch::check_eligible(
+                    &issue,
+                    state,
+                    &config,
+                    wf_id,
+                    global_max_agents,
+                    epic_graph.as_ref(),
+                );
+                if !decision.eligible {
+                    continue;
+                }
 
-            dispatch_issue(issue, state, &config, &workflow.config_rx, event_tx, wf_id);
+                dispatch_issue(
+                    issue,
+                    state,
+                    &config,
+                    &workflow.config_rx,
+                    event_tx,
+                    wf_id,
+                    &decision.base_branch,
+                );
+            }
         }
 
         // 6. Re-dispatch ready retries
@@ -178,9 +256,10 @@ fn dispatch_issue(
     config_rx: &watch::Receiver<ServiceConfig>,
     event_tx: &mpsc::Sender<OrchestratorEvent>,
     workflow_id: &WorkflowId,
+    base_branch: &str,
 ) {
     let state_key = workflow_id.state_key(&issue.identifier);
-    tracing::info!(state_key, workflow = %workflow_id, "dispatching worker");
+    tracing::info!(state_key, workflow = %workflow_id, base_branch, "dispatching worker");
 
     let stall_timeout = config.codex.stall_timeout();
     state.start_session(&state_key, issue.clone(), stall_timeout, &workflow_id.0);
@@ -190,11 +269,20 @@ fn dispatch_issue(
     let event_tx = event_tx.clone();
     let wf_id = workflow_id.clone();
     let state_key_clone = state_key.clone();
+    let base_branch = base_branch.to_string();
 
     let state_clone = state.clone();
     tokio::spawn(async move {
-        let result =
-            run_worker(&issue, &config, &config_rx, None, &state_clone, &state_key_clone).await;
+        let result = run_worker(
+            &issue,
+            &config,
+            &config_rx,
+            None,
+            &state_clone,
+            &state_key_clone,
+            Some(&base_branch),
+        )
+        .await;
 
         let (success, error) = match &result {
             Ok(true) => (true, None),
@@ -280,9 +368,16 @@ fn dispatch_retry(
         // Register the retry session
         state_clone.start_session(&state_key, issue.clone(), stall_timeout, &wf_id.0);
 
-        let result =
-            run_worker(&issue, &config, &config_rx, Some(attempt), &state_clone, &state_key)
-                .await;
+        let result = run_worker(
+            &issue,
+            &config,
+            &config_rx,
+            Some(attempt),
+            &state_clone,
+            &state_key,
+            None, // retries use existing workspace, no base_branch override
+        )
+        .await;
 
         let (success, error) = match &result {
             Ok(true) => (true, None),
@@ -383,6 +478,7 @@ async fn run_worker(
     attempt: Option<u32>,
     state: &OrchestratorState,
     state_key: &str,
+    base_branch: Option<&str>,
 ) -> Result<bool> {
     use crate::domain::session::{AgentEvent, AgentEventKind, RunStatus};
     use crate::workspace::hooks;
@@ -427,10 +523,10 @@ async fn run_worker(
             status: "Setting up workspace".into(),
         }),
     );
-    let workspace_dir = ws.ensure(&issue).await?;
+    let workspace_dir = ws.ensure(&issue, base_branch).await?;
 
     // Run before_run hook
-    ws.prepare(&issue, attempt).await?;
+    ws.prepare(&issue, attempt, base_branch).await?;
 
     // Run pre-flight verification (if enabled)
     if config.preflight.enabled {
@@ -453,11 +549,12 @@ async fn run_worker(
 
             preflight_prompt.push_str(preflight_signal_instructions());
 
-            // Use agent_subdirectory if configured
-            let preflight_dir = match &config.workspace.agent_subdirectory {
-                Some(sub) => workspace_dir.join(sub),
-                None => workspace_dir.clone(),
-            };
+            // Use agent_subdirectory if configured (Liquid-rendered per issue)
+            let preflight_dir = prompt::resolve_agent_dir(
+                &workspace_dir,
+                config.workspace.agent_subdirectory.as_deref(),
+                &issue,
+            );
 
             let preflight_runner = agent::AgentRunner::new(config.clone());
             match preflight_runner
@@ -535,7 +632,7 @@ async fn run_worker(
                     }),
                 );
 
-                ws.finish(&issue, true).await?;
+                ws.finish(&issue, true, base_branch).await?;
                 return Ok(true);
             }
         } else if let Err(e) =
@@ -552,7 +649,13 @@ async fn run_worker(
     // Build prompt from template, with PR metadata instructions appended.
     // The implementer has the best context for writing the initial PR description
     // since it performed the investigation and chose the fix.
-    let mut prompt_text = prompt::build_prompt(&config.prompt_template, &issue, attempt)?;
+    let mut prompt_text = prompt::build_prompt_full(
+        &config.prompt_template,
+        &issue,
+        attempt,
+        None,
+        base_branch,
+    )?;
     prompt_text.push_str(&pr_metadata_instructions(&issue));
 
     // Start agent session
@@ -564,11 +667,12 @@ async fn run_worker(
     );
     state.update_session_status(state_key, RunStatus::Running);
 
-    // Use agent_subdirectory if configured (e.g. "mail-ios" within the repo worktree)
-    let agent_dir = match &config.workspace.agent_subdirectory {
-        Some(sub) => workspace_dir.join(sub),
-        None => workspace_dir.clone(),
-    };
+    // Use agent_subdirectory if configured (Liquid-rendered per issue)
+    let agent_dir = prompt::resolve_agent_dir(
+        &workspace_dir,
+        config.workspace.agent_subdirectory.as_deref(),
+        &issue,
+    );
 
     let runner = agent::AgentRunner::new(config.clone());
     let (mut worker, _mcp_guard) = runner
@@ -668,8 +772,13 @@ async fn run_worker(
         if let Err(e) = tokio::fs::write(&body_file, &pr_body_text).await {
             tracing::warn!(path = %body_file.display(), "failed to write PR body temp file: {e}");
         }
+        let default_branch = &config.workspace.default_branch;
+        let base_flag = match base_branch {
+            Some(b) if b != default_branch => format!(" --base {b}"),
+            _ => String::new(),
+        };
         let pr_script = format!(
-            "git push -u origin HEAD 2>&1 && gh pr create --draft --title \"$(cat {})\" --body-file {} 2>&1",
+            "git push -u origin HEAD 2>&1 && gh pr create --draft{base_flag} --title \"$(cat {})\" --body-file {} 2>&1",
             title_file.display(),
             body_file.display(),
         );
@@ -695,6 +804,19 @@ async fn run_worker(
                     )
                     .await;
                 }
+
+                // Update Notion status on PR creation (e.g. set to "In Review")
+                if let Some(ref target_status) = config.tracker.on_pr_created_status
+                    && let Some(ref page_id) = issue.notion_page_id
+                {
+                    update_notion_status(
+                        &config.tracker,
+                        page_id,
+                        &config.tracker.property_status,
+                        target_status,
+                    )
+                    .await;
+                }
             }
             Err(e) => {
                 tracing::warn!(issue_id = issue.identifier, "PR creation failed: {e}");
@@ -712,7 +834,7 @@ async fn run_worker(
     }
 
     // Run after_run hook
-    ws.finish(&issue, success).await?;
+    ws.finish(&issue, success, base_branch).await?;
 
     Ok(success)
 }
@@ -907,7 +1029,7 @@ async fn cleanup_terminal(
     }
 }
 
-/// Extract the PR number after creation and register it for review monitoring.
+/// Extract the PR number and branch after creation and register for review monitoring.
 async fn track_created_pr(
     issue: &Issue,
     workspace_dir: &std::path::Path,
@@ -916,22 +1038,28 @@ async fn track_created_pr(
     workflow_id: &str,
     timeout: Duration,
 ) {
-    let script = "gh pr view --json number";
+    let script = "gh pr view --json number,headRefName";
     match workspace_hooks::run_hook_with_output(script, workspace_dir, timeout).await {
         Ok(output) => {
             match serde_json::from_str::<serde_json::Value>(output.trim()) {
                 Ok(data) => {
                     if let Some(number) = data["number"].as_u64() {
+                        let branch_name = data["headRefName"]
+                            .as_str()
+                            .unwrap_or("")
+                            .to_string();
                         state.track_pr(
                             state_key,
                             issue.clone(),
                             number,
                             workspace_dir.to_path_buf(),
                             workflow_id,
+                            &branch_name,
                         );
                         tracing::info!(
                             issue_id = issue.identifier,
                             pr = number,
+                            branch = %branch_name,
                             "tracking PR for review monitoring"
                         );
                     } else {
@@ -954,6 +1082,35 @@ async fn track_created_pr(
             tracing::warn!(
                 issue_id = issue.identifier,
                 "failed to get PR info for tracking: {e}"
+            );
+        }
+    }
+}
+
+/// Update a Notion page's status via MCP. Best-effort; logs warnings on failure.
+pub(super) async fn update_notion_status(
+    tracker_config: &crate::config::schema::TrackerConfig,
+    page_id: &str,
+    status_property: &str,
+    status_value: &str,
+) {
+    match NotionTracker::new(tracker_config.clone()).await {
+        Ok(mut tracker) => {
+            if let Err(e) = tracker
+                .update_issue_status(page_id, status_property, status_value)
+                .await
+            {
+                tracing::warn!(
+                    page_id,
+                    status = status_value,
+                    "failed to update Notion status: {e}"
+                );
+            }
+        }
+        Err(e) => {
+            tracing::warn!(
+                page_id,
+                "failed to connect to Notion for status update: {e}"
             );
         }
     }

--- a/src/prompt/mod.rs
+++ b/src/prompt/mod.rs
@@ -4,7 +4,7 @@ use liquid::ParserBuilder;
 
 /// Render the prompt template with issue data.
 pub fn build_prompt(template_str: &str, issue: &Issue, attempt: Option<u32>) -> Result<String> {
-    build_prompt_with_workspace(template_str, issue, attempt, None)
+    build_prompt_full(template_str, issue, attempt, None, None)
 }
 
 /// Render a template with issue data and an optional workspace path.
@@ -13,6 +13,17 @@ pub fn build_prompt_with_workspace(
     issue: &Issue,
     attempt: Option<u32>,
     workspace: Option<&str>,
+) -> Result<String> {
+    build_prompt_full(template_str, issue, attempt, workspace, None)
+}
+
+/// Render a template with issue data, workspace path, and base branch.
+pub fn build_prompt_full(
+    template_str: &str,
+    issue: &Issue,
+    attempt: Option<u32>,
+    workspace: Option<&str>,
+    base_branch: Option<&str>,
 ) -> Result<String> {
     let parser = ParserBuilder::with_stdlib()
         .build()
@@ -78,9 +89,50 @@ pub fn build_prompt_with_workspace(
         );
     }
 
+    if let Some(branch) = base_branch {
+        globals.insert(
+            "base_branch".into(),
+            liquid::model::Value::scalar(branch.to_string()),
+        );
+    }
+
     template
         .render(&globals)
         .map_err(|e| Error::Prompt(format!("failed to render template: {e}")))
+}
+
+/// Resolve the agent working directory from a workspace dir and subdirectory template.
+///
+/// If `subdirectory_template` is `None` or renders to empty/whitespace, returns
+/// `workspace_dir` directly. Otherwise, renders the template with issue context
+/// (supporting Liquid expressions like `{% if issue.title contains '[iOS]' %}mail-ios{% endif %}`)
+/// and joins the result with `workspace_dir`.
+pub fn resolve_agent_dir(
+    workspace_dir: &std::path::Path,
+    subdirectory_template: Option<&str>,
+    issue: &Issue,
+) -> std::path::PathBuf {
+    let Some(tmpl) = subdirectory_template else {
+        return workspace_dir.to_path_buf();
+    };
+    if tmpl.is_empty() {
+        return workspace_dir.to_path_buf();
+    }
+
+    match build_prompt(tmpl, issue, None) {
+        Ok(rendered) => {
+            let rendered = rendered.trim();
+            if rendered.is_empty() {
+                workspace_dir.to_path_buf()
+            } else {
+                workspace_dir.join(rendered)
+            }
+        }
+        Err(e) => {
+            tracing::warn!("failed to render agent_subdirectory template: {e}, using workspace root");
+            workspace_dir.to_path_buf()
+        }
+    }
 }
 
 #[cfg(test)]
@@ -213,5 +265,66 @@ mod tests {
         let template = "{% if issue.comments != blank %}Comments:\n{{ issue.comments }}{% else %}No comments{% endif %}";
         let result = build_prompt(template, &issue, None).unwrap();
         assert_eq!(result, "No comments");
+    }
+
+    #[test]
+    fn test_base_branch_render() {
+        let issue = Issue {
+            identifier: "TASK-1".to_string(),
+            title: "Test".to_string(),
+            description: None,
+            status: "Todo".to_string(),
+            priority: None,
+            url: None,
+            notion_page_id: None,
+            blockers: vec![],
+            source: "notion".to_string(),
+            extra: HashMap::new(),
+            comments: vec![],
+            workflow_id: String::new(),
+        };
+
+        let template = "git rebase origin/{{ base_branch }}";
+        let result = build_prompt_full(template, &issue, None, None, Some("symposium/task-TASK-99")).unwrap();
+        assert_eq!(result, "git rebase origin/symposium/task-TASK-99");
+    }
+
+    #[test]
+    fn test_resolve_agent_dir_with_liquid() {
+        use std::path::PathBuf;
+
+        let ios_issue = Issue {
+            identifier: "TASK-1".to_string(),
+            title: "[iOS] Gate: swipe gesture".to_string(),
+            description: None,
+            status: "Todo".to_string(),
+            priority: None,
+            url: None,
+            notion_page_id: None,
+            blockers: vec![],
+            source: "notion".to_string(),
+            extra: HashMap::new(),
+            comments: vec![],
+            workflow_id: String::new(),
+        };
+        let backend_issue = Issue {
+            title: "[Backend] API endpoints".to_string(),
+            ..ios_issue.clone()
+        };
+
+        let ws = PathBuf::from("/tmp/workspace");
+        let tmpl = "{% if issue.title contains '[iOS]' %}mail-ios{% endif %}";
+
+        // iOS task → subdirectory
+        let dir = resolve_agent_dir(&ws, Some(tmpl), &ios_issue);
+        assert_eq!(dir, PathBuf::from("/tmp/workspace/mail-ios"));
+
+        // Backend task → workspace root (template renders to empty)
+        let dir = resolve_agent_dir(&ws, Some(tmpl), &backend_issue);
+        assert_eq!(dir, PathBuf::from("/tmp/workspace"));
+
+        // No template → workspace root
+        let dir = resolve_agent_dir(&ws, None, &ios_issue);
+        assert_eq!(dir, PathBuf::from("/tmp/workspace"));
     }
 }

--- a/src/tracker/mcp_http.rs
+++ b/src/tracker/mcp_http.rs
@@ -13,6 +13,18 @@ pub struct HttpMcpClient {
 }
 
 impl HttpMcpClient {
+    /// Create a disconnected client for testing (no network calls).
+    #[cfg(test)]
+    pub fn disconnected() -> Self {
+        Self {
+            url: String::new(),
+            http: reqwest::Client::new(),
+            oauth: OAuthClient::new("http://test"),
+            next_id: AtomicU64::new(1),
+            session_id: None,
+        }
+    }
+
     pub async fn new(url: &str) -> Result<Self> {
         let oauth = OAuthClient::new(url);
         let mut client = Self {

--- a/src/tracker/mod.rs
+++ b/src/tracker/mod.rs
@@ -26,4 +26,19 @@ pub trait TrackerClient {
     async fn fetch_comments(&mut self, _page_id: &str) -> Result<Vec<Comment>> {
         Ok(vec![])
     }
+
+    /// Update the status of an issue in the tracker. Default no-op.
+    async fn update_issue_status(
+        &mut self,
+        _page_id: &str,
+        _status_property: &str,
+        _status_value: &str,
+    ) -> Result<()> {
+        Ok(())
+    }
+
+    /// Fetch ALL sub-tasks of an epic regardless of status (for dependency graph).
+    async fn fetch_all_epic_tasks(&mut self) -> Result<Vec<Issue>> {
+        Ok(vec![])
+    }
 }

--- a/src/tracker/notion.rs
+++ b/src/tracker/notion.rs
@@ -77,7 +77,34 @@ impl NotionTracker {
         if let Some(ref prop) = self.config.skip_if_set {
             query.push_str(&format!(" AND \"{prop}\" IS NULL"));
         }
+        if let Some(ref parent_id) = self.config.parent_page_id {
+            query.push_str(&format!(
+                " AND \"{}\" LIKE '%{parent_id}%'",
+                self.config.property_parent
+            ));
+        }
+        if let Some(ref type_prop) = self.config.property_type
+            && let Some(ref types) = self.config.eligible_types
+            && !types.is_empty()
+        {
+            let type_list = types
+                .iter()
+                .map(|t| format!("'{t}'"))
+                .collect::<Vec<_>>()
+                .join(", ");
+            query.push_str(&format!(" AND \"{type_prop}\" IN ({type_list})"));
+        }
         query
+    }
+
+    /// Build a query that fetches ALL sub-tasks of the epic regardless of status.
+    /// Used to build the complete dependency graph for epic workflows.
+    fn build_epic_all_tasks_query(&self, ds_id: &str) -> Option<String> {
+        let parent_id = self.config.parent_page_id.as_ref()?;
+        Some(format!(
+            "SELECT * FROM \"{ds_id}\" WHERE \"{}\" LIKE '%{parent_id}%'",
+            self.config.property_parent
+        ))
     }
 
     /// Unwrap the MCP tool response to get the inner data.
@@ -405,6 +432,50 @@ impl TrackerClient for NotionTracker {
             .await
     }
 
+    async fn update_issue_status(
+        &mut self,
+        page_id: &str,
+        status_property: &str,
+        status_value: &str,
+    ) -> Result<()> {
+        let args = serde_json::json!({
+            "page_id": page_id,
+            "properties": {
+                status_property: {
+                    "status": {
+                        "name": status_value
+                    }
+                }
+            }
+        });
+        self.client
+            .call_tool("notion-update-page", args)
+            .await
+            .map_err(|e| Error::Tracker(format!("failed to update issue status: {e}")))?;
+        tracing::info!(page_id, status = status_value, "updated Notion issue status");
+        Ok(())
+    }
+
+    async fn fetch_all_epic_tasks(&mut self) -> Result<Vec<Issue>> {
+        let ds_url = self.data_source_url();
+        let Some(sql) = self.build_epic_all_tasks_query(&ds_url) else {
+            return Ok(vec![]);
+        };
+        let result = self
+            .client
+            .call_tool(
+                "notion-query-data-sources",
+                serde_json::json!({
+                    "data": {
+                        "data_source_urls": [&ds_url],
+                        "query": sql
+                    }
+                }),
+            )
+            .await?;
+        Ok(self.extract_issues(&result))
+    }
+
     async fn fetch_comments(&mut self, page_id: &str) -> Result<Vec<Comment>> {
         let result = self
             .client
@@ -510,5 +581,107 @@ mod tests {
         let comments = NotionTracker::parse_comments(&data);
         assert_eq!(comments.len(), 1);
         assert_eq!(comments[0].body, "Direct text");
+    }
+
+    fn make_config() -> TrackerConfig {
+        TrackerConfig {
+            database_id: "db-123".to_string(),
+            ..TrackerConfig::default()
+        }
+    }
+
+    #[test]
+    fn build_status_query_basic() {
+        let config = make_config();
+        let tracker = NotionTracker {
+            client: McpTransport::Http(HttpMcpClient::disconnected()),
+            config,
+            data_source_id: None,
+        };
+        let ds = "collection://db-123";
+        let q = tracker.build_status_query(ds, &["Todo".to_string(), "In Progress".to_string()]);
+        assert!(q.contains("\"Status\" IN ('Todo', 'In Progress')"));
+        // Should not contain parent or type filters
+        assert!(!q.contains("Parent Task"));
+        assert!(!q.contains("Type"));
+    }
+
+    #[test]
+    fn build_status_query_with_parent_page() {
+        let config = TrackerConfig {
+            parent_page_id: Some("abc123".to_string()),
+            ..make_config()
+        };
+        let tracker = NotionTracker {
+            client: McpTransport::Http(HttpMcpClient::disconnected()),
+            config,
+            data_source_id: None,
+        };
+        let ds = "collection://db-123";
+        let q = tracker.build_status_query(ds, &["Todo".to_string()]);
+        assert!(q.contains("\"Parent Task\" LIKE '%abc123%'"));
+    }
+
+    #[test]
+    fn build_status_query_with_type_filter() {
+        let config = TrackerConfig {
+            property_type: Some("Type".to_string()),
+            eligible_types: Some(vec!["Eng".to_string(), "Feature".to_string()]),
+            ..make_config()
+        };
+        let tracker = NotionTracker {
+            client: McpTransport::Http(HttpMcpClient::disconnected()),
+            config,
+            data_source_id: None,
+        };
+        let ds = "collection://db-123";
+        let q = tracker.build_status_query(ds, &["Todo".to_string()]);
+        assert!(q.contains("\"Type\" IN ('Eng', 'Feature')"));
+    }
+
+    #[test]
+    fn build_status_query_type_filter_requires_both_fields() {
+        // Only property_type set, no eligible_types → no filter
+        let config = TrackerConfig {
+            property_type: Some("Type".to_string()),
+            eligible_types: None,
+            ..make_config()
+        };
+        let tracker = NotionTracker {
+            client: McpTransport::Http(HttpMcpClient::disconnected()),
+            config,
+            data_source_id: None,
+        };
+        let ds = "collection://db-123";
+        let q = tracker.build_status_query(ds, &["Todo".to_string()]);
+        assert!(!q.contains("Type"));
+    }
+
+    #[test]
+    fn build_epic_all_tasks_query_returns_none_without_parent() {
+        let config = make_config();
+        let tracker = NotionTracker {
+            client: McpTransport::Http(HttpMcpClient::disconnected()),
+            config,
+            data_source_id: None,
+        };
+        assert!(tracker.build_epic_all_tasks_query("ds").is_none());
+    }
+
+    #[test]
+    fn build_epic_all_tasks_query_with_parent() {
+        let config = TrackerConfig {
+            parent_page_id: Some("epic-page-id".to_string()),
+            ..make_config()
+        };
+        let tracker = NotionTracker {
+            client: McpTransport::Http(HttpMcpClient::disconnected()),
+            config,
+            data_source_id: None,
+        };
+        let q = tracker.build_epic_all_tasks_query("collection://db-123").unwrap();
+        assert!(q.contains("\"Parent Task\" LIKE '%epic-page-id%'"));
+        // Should NOT contain status filter
+        assert!(!q.contains("Status"));
     }
 }

--- a/src/workspace/mod.rs
+++ b/src/workspace/mod.rs
@@ -31,24 +31,26 @@ impl WorkspaceManager {
         Ok(dir)
     }
 
-    /// Render a hook script through Liquid with issue context and workspace path.
+    /// Render a hook script through Liquid with issue context, workspace path, and base branch.
     fn render_hook(
         &self,
         hook: &str,
         issue: &Issue,
         attempt: Option<u32>,
         workspace: &Path,
+        base_branch: Option<&str>,
     ) -> Result<String> {
-        prompt::build_prompt_with_workspace(
+        prompt::build_prompt_full(
             hook,
             issue,
             attempt,
             workspace.to_str(),
+            base_branch,
         )
     }
 
     /// Ensure the workspace directory exists, run after_create hook if newly created.
-    pub async fn ensure(&self, issue: &Issue) -> Result<PathBuf> {
+    pub async fn ensure(&self, issue: &Issue, base_branch: Option<&str>) -> Result<PathBuf> {
         let dir = self.workspace_dir(&issue.identifier)?;
         let newly_created = !dir.exists();
 
@@ -66,7 +68,7 @@ impl WorkspaceManager {
                     })?;
                 }
                 tracing::info!(issue_key = issue.identifier, path = %dir.display(), "creating workspace");
-                let rendered = self.render_hook(hook, issue, None, &dir)?;
+                let rendered = self.render_hook(hook, issue, None, &dir, base_branch)?;
                 // Run hook from the parent directory since workspace doesn't exist yet
                 let cwd = dir.parent().unwrap_or(&dir);
                 hooks::run_hook(&rendered, cwd, config.hooks.timeout()).await?;
@@ -85,22 +87,22 @@ impl WorkspaceManager {
     }
 
     /// Run the before_run hook in the workspace.
-    pub async fn prepare(&self, issue: &Issue, attempt: Option<u32>) -> Result<PathBuf> {
+    pub async fn prepare(&self, issue: &Issue, attempt: Option<u32>, base_branch: Option<&str>) -> Result<PathBuf> {
         let dir = self.workspace_dir(&issue.identifier)?;
         let config = self.config_rx.borrow().clone();
         if let Some(hook) = &config.hooks.before_run {
-            let rendered = self.render_hook(hook, issue, attempt, &dir)?;
+            let rendered = self.render_hook(hook, issue, attempt, &dir, base_branch)?;
             hooks::run_hook(&rendered, &dir, config.hooks.timeout()).await?;
         }
         Ok(dir)
     }
 
     /// Run the after_run hook in the workspace.
-    pub async fn finish(&self, issue: &Issue, success: bool) -> Result<()> {
+    pub async fn finish(&self, issue: &Issue, success: bool, base_branch: Option<&str>) -> Result<()> {
         let dir = self.workspace_dir(&issue.identifier)?;
         let config = self.config_rx.borrow().clone();
         if let Some(hook) = &config.hooks.after_run {
-            let rendered = self.render_hook(hook, issue, None, &dir)?;
+            let rendered = self.render_hook(hook, issue, None, &dir, base_branch)?;
             let mut env = std::collections::HashMap::new();
             env.insert(
                 "RUN_SUCCESS".to_string(),


### PR DESCRIPTION
## Summary

- Adds infrastructure for executing **epics** — parent tasks with sub-tasks connected by a dependency graph
- Implements 7 features: parent page scoping, epic dependency graph, blocker-aware dispatch with branch stacking, dynamic agent subdirectory via Liquid templates, type filtering, Notion status updates, and branch-aware workspace/PR creation
- Adds configurable `default_branch` for repos not using `main`

## Changes

**Config** (`src/config/schema.rs`):
- 6 new `TrackerConfig` fields: `parent_page_id`, `property_parent`, `property_type`, `eligible_types`, `on_pr_created_status`, `on_pr_merged_status`
- New `workspace.default_branch` field (defaults to `"main"`)

**Epic dependency graph** (`src/domain/epic.rs` — new):
- `EpicGraph` with Mermaid `graph TD` parsing and `Blocked by` relation merging
- `check_eligibility()` computes base branches: single dep → stack, fan-in → default branch
- Warns on unmatched Mermaid nodes/edges to surface graph incompleteness

**Blocker-aware dispatch** (`src/orchestrator/dispatch.rs`):
- New `check_eligible()` returning `DispatchDecision` with `base_branch`
- `build_task_states()` maps orchestrator state to `TaskState` enum, filtered by workflow
- Guards against dispatching epic tasks when the dependency graph isn't available

**Tracker** (`src/tracker/mod.rs`, `src/tracker/notion.rs`):
- `update_issue_status()` and `fetch_all_epic_tasks()` on `TrackerClient` trait
- Parent page filter and type filter in `build_status_query()`

**Orchestrator integration** (`src/orchestrator/tick.rs`, `src/orchestrator/pr_review.rs`):
- Epic graph initialization on first tick with `parent_page_id`
- `base_branch` threaded through dispatch → workspace hooks → PR creation (`--base` flag)
- Notion status updates on PR creation and merge detection
- Dynamic `agent_subdirectory` via Liquid template rendering (`resolve_agent_dir`)

**Prompt/Workspace** (`src/prompt/mod.rs`, `src/workspace/mod.rs`):
- `build_prompt_full()` with `base_branch` template variable (`{{ base_branch }}`)
- `resolve_agent_dir()` renders subdirectory templates per-issue
- All hook methods accept `base_branch: Option<&str>`

## Test plan

- [x] `cargo build --release` — succeeds
- [x] `cargo clippy` — 0 warnings
- [x] `cargo test` — 111 tests pass (14 new epic tests, 7 new dispatch tests, 2 new prompt tests, 6 new tracker tests)
- [ ] Manual: run against an epic with `max_concurrent_agents: 1`, verify only root tasks dispatch first
- [ ] Manual: verify downstream tasks become eligible after upstream PRs are created
- [ ] Manual: verify branch stacking (`--base` flag) on single-dependency tasks
- [ ] Manual: verify fan-in tasks base off default branch