### PR TITLE
Add workspace cleanup: before_remove hook and age-based reaper

### DIFF
--- a/src/config/env.rs
+++ b/src/config/env.rs
@@ -47,6 +47,9 @@ pub fn expand_config(config: &mut ServiceConfig) {
     if let Some(ref s) = config.hooks.after_run {
         config.hooks.after_run = Some(expand_vars(s));
     }
+    if let Some(ref s) = config.hooks.before_remove {
+        config.hooks.before_remove = Some(expand_vars(s));
+    }
 
     config.sentry.org = expand_vars(&config.sentry.org);
     config.sentry.project = expand_vars(&config.sentry.project);

--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -154,6 +154,10 @@ pub struct WorkspaceConfig {
     pub root: String,
     /// Subdirectory within the workspace to use as the agent's working directory.
     pub agent_subdirectory: Option<String>,
+    /// Reap workspaces whose top-level mtime is older than this many days.
+    /// Running sessions and workspaces with tracked open PRs are always skipped.
+    /// `None` disables the reaper.
+    pub max_age_days: Option<u64>,
 }
 
 impl Default for WorkspaceConfig {
@@ -161,7 +165,15 @@ impl Default for WorkspaceConfig {
         Self {
             root: "~/symposium_workspaces".to_string(),
             agent_subdirectory: None,
+            max_age_days: None,
         }
+    }
+}
+
+impl WorkspaceConfig {
+    pub fn max_age(&self) -> Option<Duration> {
+        self.max_age_days
+            .map(|d| Duration::from_secs(d * 24 * 60 * 60))
     }
 }
 
@@ -171,6 +183,12 @@ pub struct HooksConfig {
     pub after_create: Option<String>,
     pub before_run: Option<String>,
     pub after_run: Option<String>,
+    /// Optional shell hook rendered and run from the workspace's parent
+    /// directory before the workspace itself is deleted. Typical use:
+    /// `git -C <repo> worktree remove --force {{ workspace }}` so worktree
+    /// metadata is pruned along with the files. If the hook fails we still
+    /// fall back to `remove_dir_all` so disk is always reclaimed.
+    pub before_remove: Option<String>,
     pub timeout_ms: u64,
 }
 
@@ -180,6 +198,7 @@ impl Default for HooksConfig {
             after_create: None,
             before_run: None,
             after_run: None,
+            before_remove: None,
             timeout_ms: 300_000,
         }
     }

--- a/src/domain/state.rs
+++ b/src/domain/state.rs
@@ -231,6 +231,18 @@ impl OrchestratorState {
             .count()
     }
 
+    /// Issue identifiers currently running under the given workflow.
+    pub fn running_issue_ids_for_workflow(&self, workflow_id: &str) -> Vec<String> {
+        self.inner
+            .lock()
+            .unwrap()
+            .running
+            .values()
+            .filter(|e| e.workflow_id == workflow_id)
+            .map(|e| e.issue.identifier.clone())
+            .collect()
+    }
+
     pub fn start_session(&self, state_key: &str, issue: Issue, stall_timeout: Duration, workflow_id: &str) {
         let session = LiveSession::new(state_key.to_string());
         let entry = RunningEntry {

--- a/src/orchestrator/tick.rs
+++ b/src/orchestrator/tick.rs
@@ -167,7 +167,109 @@ pub async fn run_workflow_tick(
         .await;
     }
 
+    // 9. Age-based workspace reaper (disabled unless workspace.max_age_days is set).
+    //    Catches orphaned workspaces whose issue never reached a terminal state
+    //    (e.g. Notion row deleted, workflow removed, PR already merged and closed).
+    if let Some(max_age) = config.workspace.max_age() {
+        reap_stale_workspaces(max_age, state, &workflow.config_rx, wf_id);
+    }
+
     Ok(())
+}
+
+/// Pure selection logic for the reaper — given the candidate directory names,
+/// the skip set (sanitized names of running issues + tracked open PRs), the
+/// "now" reference, a resolver that returns each workspace's mtime, and the
+/// age threshold, return the subset that should be deleted.
+///
+/// Split out so we can test the decision table without touching the real
+/// filesystem or a live orchestrator.
+fn select_reap_candidates<F>(
+    workspaces: &[String],
+    skip: &std::collections::HashSet<String>,
+    now: std::time::SystemTime,
+    max_age: Duration,
+    mut mtime_of: F,
+) -> Vec<String>
+where
+    F: FnMut(&str) -> Option<std::time::SystemTime>,
+{
+    workspaces
+        .iter()
+        .filter(|name| !skip.contains(name.as_str()))
+        .filter(|name| match mtime_of(name) {
+            Some(t) => now.duration_since(t).map(|age| age >= max_age).unwrap_or(false),
+            None => false,
+        })
+        .cloned()
+        .collect()
+}
+
+fn reap_skip_set(
+    state: &OrchestratorState,
+    workflow_id: &WorkflowId,
+) -> std::collections::HashSet<String> {
+    use crate::workspace::safety::sanitize_key;
+    let mut skip: std::collections::HashSet<String> = state
+        .running_issue_ids_for_workflow(&workflow_id.0)
+        .into_iter()
+        .map(|id| sanitize_key(&id))
+        .collect();
+    skip.extend(
+        state
+            .open_prs()
+            .iter()
+            .map(|pr| sanitize_key(&pr.issue.identifier)),
+    );
+    skip
+}
+
+/// Delete workspaces whose top-level mtime is older than `max_age`, skipping
+/// anything currently running or backing a tracked open PR. Runs asynchronously
+/// — tick loop keeps moving.
+fn reap_stale_workspaces(
+    max_age: Duration,
+    state: &OrchestratorState,
+    config_rx: &watch::Receiver<ServiceConfig>,
+    workflow_id: &WorkflowId,
+) {
+    let ws = WorkspaceManager::new(config_rx.clone());
+    let workspaces = match ws.list_workspaces() {
+        Ok(list) => list,
+        Err(e) => {
+            tracing::warn!(workflow = %workflow_id, "reaper: failed to list workspaces: {e}");
+            return;
+        }
+    };
+    if workspaces.is_empty() {
+        return;
+    }
+
+    let skip = reap_skip_set(state, workflow_id);
+    let root = std::path::PathBuf::from(&config_rx.borrow().workspace.root);
+    let wf_id = workflow_id.clone();
+    tokio::spawn(async move {
+        let now = std::time::SystemTime::now();
+        let targets = select_reap_candidates(&workspaces, &skip, now, max_age, |name| {
+            std::fs::metadata(root.join(name))
+                .ok()
+                .and_then(|m| m.modified().ok())
+        });
+        for name in targets {
+            tracing::info!(
+                workflow = %wf_id,
+                workspace = %name,
+                "reaping stale workspace"
+            );
+            if let Err(e) = ws.remove(&name).await {
+                tracing::warn!(
+                    workflow = %wf_id,
+                    workspace = %name,
+                    "reaper: failed to remove workspace: {e}"
+                );
+            }
+        }
+    });
 }
 
 /// Spawn a worker task for a new issue.
@@ -969,5 +1071,68 @@ async fn cleanup_terminal_sentry(
     match tracker.fetch_terminal_issues().await {
         Ok(issues) => remove_terminal_workspaces(issues, state, config_rx, workflow_id),
         Err(e) => tracing::warn!(workflow = %workflow_id, "failed to fetch terminal Sentry issues for cleanup: {e}"),
+    }
+}
+
+#[cfg(test)]
+mod reaper_tests {
+    use super::*;
+    use std::collections::HashSet;
+    use std::time::{Duration, SystemTime};
+
+    fn s(x: &str) -> String {
+        x.to_string()
+    }
+
+    #[test]
+    fn reaps_only_stale_unskipped() {
+        let workspaces = vec![s("OLD"), s("FRESH"), s("SKIP")];
+        let skip: HashSet<String> = [s("SKIP")].into();
+        let now = SystemTime::now();
+        let max_age = Duration::from_secs(7 * 24 * 3600);
+
+        let ages: std::collections::HashMap<&str, SystemTime> = [
+            ("OLD", now - Duration::from_secs(30 * 24 * 3600)),
+            ("FRESH", now - Duration::from_secs(3600)),
+            ("SKIP", now - Duration::from_secs(60 * 24 * 3600)),
+        ]
+        .into();
+
+        let out = select_reap_candidates(&workspaces, &skip, now, max_age, |n| {
+            ages.get(n).copied()
+        });
+        assert_eq!(out, vec![s("OLD")]);
+    }
+
+    #[test]
+    fn skips_missing_mtime() {
+        let workspaces = vec![s("NO_METADATA")];
+        let skip = HashSet::new();
+        let now = SystemTime::now();
+        let out = select_reap_candidates(
+            &workspaces,
+            &skip,
+            now,
+            Duration::from_secs(60),
+            |_| None,
+        );
+        assert!(out.is_empty());
+    }
+
+    #[test]
+    fn skips_future_mtime() {
+        // A workspace with mtime in the future (clock skew) should not be reaped.
+        let workspaces = vec![s("FUTURE")];
+        let skip = HashSet::new();
+        let now = SystemTime::now();
+        let future = now + Duration::from_secs(3600);
+        let out = select_reap_candidates(
+            &workspaces,
+            &skip,
+            now,
+            Duration::from_secs(60),
+            |_| Some(future),
+        );
+        assert!(out.is_empty());
     }
 }

--- a/src/workspace/mod.rs
+++ b/src/workspace/mod.rs
@@ -111,15 +111,67 @@ impl WorkspaceManager {
         Ok(())
     }
 
-    /// Remove a workspace directory (for terminal issues).
+    /// Remove a workspace directory (for terminal issues or reaping).
+    ///
+    /// If `hooks.before_remove` is configured, it is rendered with the issue
+    /// (if available) and the workspace path, then executed from the workspace
+    /// root's parent directory — this matters for `git worktree remove`, which
+    /// refuses to run from inside the target worktree. A final `remove_dir_all`
+    /// sweeps anything the hook left behind so disk is always reclaimed.
     pub async fn remove(&self, issue_key: &str) -> Result<()> {
+        self.remove_with_issue(issue_key, None).await
+    }
+
+    /// Same as [`remove`] but passes an Issue into the hook template so users
+    /// can reference `{{ issue.identifier }}` etc. from `before_remove`.
+    pub async fn remove_with_issue(&self, issue_key: &str, issue: Option<&Issue>) -> Result<()> {
         let dir = self.workspace_dir(issue_key)?;
+        if !dir.exists() {
+            return Ok(());
+        }
+
+        let config = self.config_rx.borrow().clone();
+        if let Some(hook) = &config.hooks.before_remove {
+            // Synthesize a minimal issue if one wasn't supplied (age-based
+            // reaper path doesn't have tracker metadata for orphan workspaces).
+            let synth;
+            let issue_ref = match issue {
+                Some(i) => i,
+                None => {
+                    synth = Issue {
+                        identifier: issue_key.to_string(),
+                        title: String::new(),
+                        description: None,
+                        status: String::new(),
+                        priority: None,
+                        url: None,
+                        notion_page_id: None,
+                        blockers: vec![],
+                        source: "reaper".to_string(),
+                        extra: std::collections::HashMap::new(),
+                        comments: vec![],
+                        workflow_id: String::new(),
+                    };
+                    &synth
+                }
+            };
+            let rendered = self.render_hook(hook, issue_ref, None, &dir)?;
+            let cwd = dir.parent().unwrap_or(&dir);
+            if let Err(e) = hooks::run_hook(&rendered, cwd, config.hooks.timeout()).await {
+                tracing::warn!(
+                    issue_key,
+                    path = %dir.display(),
+                    "before_remove hook failed, falling back to filesystem removal: {e}"
+                );
+            }
+        }
+
         if dir.exists() {
             tokio::fs::remove_dir_all(&dir).await.map_err(|e| {
                 Error::Workspace(format!("failed to remove workspace {}: {e}", dir.display()))
             })?;
-            tracing::info!(issue_key, path = %dir.display(), "removed workspace");
         }
+        tracing::info!(issue_key, path = %dir.display(), "removed workspace");
         Ok(())
     }
 
@@ -140,5 +192,75 @@ impl WorkspaceManager {
                 }
         }
         Ok(keys)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::schema::ServiceConfig;
+    use tempfile::TempDir;
+
+    fn manager_with_root(root: &Path) -> (WorkspaceManager, watch::Sender<ServiceConfig>) {
+        let mut config = ServiceConfig::default();
+        config.workspace.root = root.to_string_lossy().into_owned();
+        let (tx, rx) = watch::channel(config);
+        (WorkspaceManager::new(rx), tx)
+    }
+
+    #[tokio::test]
+    async fn remove_deletes_directory() {
+        let tmp = TempDir::new().unwrap();
+        let (ws, _tx) = manager_with_root(tmp.path());
+        let target = tmp.path().join("ABC-1");
+        tokio::fs::create_dir_all(&target).await.unwrap();
+        tokio::fs::write(target.join("file.txt"), b"hi").await.unwrap();
+
+        ws.remove("ABC-1").await.unwrap();
+        assert!(!target.exists(), "workspace dir should be gone");
+    }
+
+    #[tokio::test]
+    async fn remove_runs_before_remove_hook() {
+        let tmp = TempDir::new().unwrap();
+        let sentinel = tmp.path().join("hook-ran");
+        let (ws, tx) = manager_with_root(tmp.path());
+
+        // Hook writes a sentinel file with the workspace path so we can
+        // verify it ran with the expected template expansion.
+        let hook = format!(
+            r#"printf '%s' "{{{{ workspace }}}}" > {}"#,
+            sentinel.display()
+        );
+        tx.send_modify(|c| c.hooks.before_remove = Some(hook));
+
+        let target = tmp.path().join("XYZ-9");
+        tokio::fs::create_dir_all(&target).await.unwrap();
+
+        ws.remove("XYZ-9").await.unwrap();
+
+        let written = tokio::fs::read_to_string(&sentinel).await.unwrap();
+        assert_eq!(written, target.to_string_lossy());
+        assert!(!target.exists(), "workspace dir should still be gone after hook");
+    }
+
+    #[tokio::test]
+    async fn remove_falls_back_when_hook_fails() {
+        let tmp = TempDir::new().unwrap();
+        let (ws, tx) = manager_with_root(tmp.path());
+        tx.send_modify(|c| c.hooks.before_remove = Some("exit 1".into()));
+
+        let target = tmp.path().join("FAIL-1");
+        tokio::fs::create_dir_all(&target).await.unwrap();
+        ws.remove("FAIL-1").await.unwrap();
+
+        assert!(!target.exists(), "fallback remove_dir_all should still reclaim disk");
+    }
+
+    #[tokio::test]
+    async fn remove_missing_workspace_is_noop() {
+        let tmp = TempDir::new().unwrap();
+        let (ws, _tx) = manager_with_root(tmp.path());
+        ws.remove("NEVER-EXISTED").await.unwrap();
     }
 }


### PR DESCRIPTION
## Summary

Adds two complementary cleanup paths so symposium stops hoarding worktrees (my local `symposium_workspaces` hit 270 GB across 32 workspaces).

**`hooks.before_remove`** — user-defined shell script rendered from the workspace's *parent* directory before deletion, with the workspace path exposed as `{{ workspace }}`. Intended use:

```yaml
hooks:
  before_remove: "git -C ~/Developer/Notion/mail worktree remove --force {{ workspace }}"
```

This fixes the existing orphan-ref leak: today `cleanup_terminal` uses `remove_dir_all`, which deletes files but leaves stale entries in the parent repo's `.git/worktrees/`. If the hook fails or leaves residue, we still fall back to `remove_dir_all`, so disk is always reclaimed.

**`workspace.max_age_days`** — opt-in, filesystem-driven reaper invoked at the end of each workflow tick. Skips:
- currently-running issues (`state.running_issue_ids_for_workflow`)
- anything in `state.open_prs()` (cross-workflow — the PR review monitor needs those on disk)
- workspaces younger than the threshold
- workspaces with missing or future mtimes

Catches orphan workspaces the tracker never marks terminal: Notion row deleted, workflow removed, PR merged and closed without a status update, etc.

The selection logic is factored out as a pure `select_reap_candidates(workspaces, skip, now, max_age, mtime_of)` so the decision table is unit-tested without filesystem or orchestrator setup.

## Test plan

- [x] `cargo test` — 88 tests pass, 7 new (4 for `WorkspaceManager::remove`, 3 for the reaper selector)
- [x] `cargo clippy --all-targets` — clean
- [ ] Manual: set `max_age_days: 14` + `before_remove` with `git worktree remove --force`, confirm stale workspaces are torn down on next tick and parent repo's `.git/worktrees/` stays clean

## Rollout notes

Both features are opt-in and off by default (`before_remove: None`, `max_age_days: None`), so this is a no-op for anyone who doesn't update their config.