### PR TITLE
Scope Sentry search to the configured project

### DIFF
--- a/WORKFLOW.example.md
+++ b/WORKFLOW.example.md
@@ -119,9 +119,16 @@ server:
 # sentry:
 #   enabled: true
 #   org: "my-org"
+#   # Passed to Sentry's MCP server as `projectSlugOrId` for hard server-side
+#   # scoping; also used to derive an expected short-id prefix (e.g. `MY-PROJECT-`)
+#   # for a defense-in-depth client-side filter.
 #   project: "my-project"
 #   mcp_url: "https://mcp.sentry.dev/mcp"  # Sentry MCP server (OAuth auth)
-#   query: "release:[my-app@1.7.*,my-app@1.8.*]"  # Sentry search syntax
+#   # Extra Sentry search filters appended after `is:unresolved` / `is:resolved`.
+#   # Do NOT include `project:<slug>` here — the project is passed structurally
+#   # above. Putting it in this string lets Sentry's NL parser treat the project
+#   # as a soft hint, and unrelated projects can leak through.
+#   query: "release:[my-app@1.7.*,my-app@1.8.*]"
 #   min_events: 5                           # skip issues below this threshold
 #   id_prefix: "SENTRY:"                    # default: "sentry:" — prefix for Sentry issue IDs
 

--- a/examples/sentry_probe.rs
+++ b/examples/sentry_probe.rs
@@ -1,0 +1,185 @@
+//! Probe a few argument shapes for the Sentry MCP `search_issues` tool to find
+//! one that reliably scopes to a single Sentry project.
+//!
+//! Run with:
+//!   cargo run --example sentry_probe
+//!
+//! Reads OAuth state from the same cache directory as the orchestrator, so make
+//! sure you've authorized the Sentry MCP at least once via a normal orchestrator
+//! run before invoking this.
+
+use serde_json::{Value, json};
+use std::collections::BTreeMap;
+use symposium::tracker::mcp_http::HttpMcpClient;
+
+const SENTRY_MCP_URL: &str = "https://mcp.sentry.dev/mcp";
+const ORG: &str = "notion";
+const PROJECT: &str = "mail-ios";
+// Match the existing config — keep filters identical so we're comparing the
+// scoping behavior, not the filter set.
+const EXTRA: &str = "error.unhandled:true";
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("warn")),
+        )
+        .init();
+
+    let mut client = HttpMcpClient::new(SENTRY_MCP_URL).await?;
+
+    // --- 1) Dump the search_issues schema so we know what args the server actually accepts.
+    println!("\n=== search_issues schema ===");
+    let tools = client.list_tools().await?;
+    if let Some(arr) = tools.get("tools").and_then(|v| v.as_array())
+        && let Some(t) = arr.iter().find(|t| {
+            t.get("name").and_then(|n| n.as_str()) == Some("search_issues")
+        })
+    {
+        if let Some(schema) = t.get("inputSchema") {
+            println!("{}", serde_json::to_string_pretty(schema)?);
+        } else {
+            println!("(no inputSchema field)");
+        }
+    } else {
+        println!("(search_issues tool not found)");
+    }
+
+    // --- 2) Run several call shapes and summarize what comes back.
+    let nl_with_project = format!("project:{PROJECT} is:unresolved {EXTRA}");
+    let nl_without_project = format!("is:unresolved {EXTRA}");
+
+    let variants: Vec<(&str, Value)> = vec![
+        (
+            "A) baseline: NL only, project encoded inside naturalLanguageQuery",
+            json!({
+                "organizationSlug": ORG,
+                "naturalLanguageQuery": nl_with_project,
+            }),
+        ),
+        (
+            "B) NL + structured projectSlug",
+            json!({
+                "organizationSlug": ORG,
+                "projectSlug": PROJECT,
+                "naturalLanguageQuery": nl_without_project,
+            }),
+        ),
+        (
+            "C) NL + structured projectSlugs (array)",
+            json!({
+                "organizationSlug": ORG,
+                "projectSlugs": [PROJECT],
+                "naturalLanguageQuery": nl_without_project,
+            }),
+        ),
+        (
+            "D) literal `query` arg (bypass the NLU)",
+            json!({
+                "organizationSlug": ORG,
+                "query": nl_with_project,
+            }),
+        ),
+        (
+            "E) literal `query` + structured projectSlug",
+            json!({
+                "organizationSlug": ORG,
+                "projectSlug": PROJECT,
+                "query": format!("is:unresolved {EXTRA}"),
+            }),
+        ),
+        (
+            "F) SCHEMA-CORRECT: projectSlugOrId + query, limit 100",
+            json!({
+                "organizationSlug": ORG,
+                "projectSlugOrId": PROJECT,
+                "query": format!("is:unresolved {EXTRA}"),
+                "limit": 100,
+            }),
+        ),
+        (
+            "G) SCHEMA-CORRECT, no extra filter (sanity: full mail-ios unresolved)",
+            json!({
+                "organizationSlug": ORG,
+                "projectSlugOrId": PROJECT,
+                "query": "is:unresolved",
+                "limit": 100,
+            }),
+        ),
+    ];
+
+    for (label, args) in variants {
+        println!("\n=== {label} ===");
+        println!(
+            "args: {}",
+            serde_json::to_string(&args).unwrap_or_default()
+        );
+        match client.call_tool("search_issues", args).await {
+            Ok(result) => summarize(&result),
+            Err(e) => println!("ERROR: {e}"),
+        }
+    }
+
+    Ok(())
+}
+
+/// Summarize a tool response: error flag, total issue count, and the breakdown
+/// of short-ID prefixes so we can see whether `mail-web` etc. leaked through.
+fn summarize(result: &Value) {
+    let is_error = result
+        .get("isError")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false);
+    if is_error {
+        println!("isError=true");
+    }
+
+    let text = extract_text(result);
+
+    // Sentry MCP responses sometimes include a "Found **N** issues:" line.
+    let found_line = text
+        .lines()
+        .find(|l| l.contains("Found") && l.contains("issues"))
+        .unwrap_or("(no 'Found N issues' line)");
+    println!("header: {}", found_line.trim());
+
+    // Pull every short-id from "## N. [SHORT-ID](url)" headers.
+    let re = regex::Regex::new(r"##\s+\d+\.\s+\[([A-Z0-9-]+)\]").unwrap();
+    let mut prefixes: BTreeMap<String, usize> = BTreeMap::new();
+    let mut total = 0usize;
+    for caps in re.captures_iter(&text) {
+        total += 1;
+        let id = caps.get(1).map(|m| m.as_str()).unwrap_or("");
+        // Prefix = everything up to the last "-".
+        let prefix = id.rsplit_once('-').map(|(p, _)| p).unwrap_or(id);
+        *prefixes.entry(prefix.to_string()).or_insert(0) += 1;
+    }
+    println!("parsed total: {total}");
+    if prefixes.is_empty() {
+        println!("prefixes: (none parsed — first 400 chars of body follows)");
+        let preview: String = text.chars().take(400).collect();
+        println!("--- body preview ---\n{preview}\n--- end preview ---");
+    } else {
+        println!("prefixes:");
+        for (p, n) in prefixes {
+            println!("  {p:<20} {n}");
+        }
+    }
+}
+
+fn extract_text(result: &Value) -> String {
+    if let Some(content) = result.get("content").and_then(|v| v.as_array()) {
+        return content
+            .iter()
+            .filter_map(|b| b.get("text").and_then(|v| v.as_str()))
+            .collect::<Vec<_>>()
+            .join("\n");
+    }
+    result
+        .get("text")
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+        .to_string()
+}

--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -38,9 +38,13 @@ pub struct SentryConfig {
     /// MCP server URL for Sentry (uses OAuth for auth).
     #[serde(default = "default_sentry_mcp_url")]
     pub mcp_url: String,
-    /// Raw Sentry search query appended after `is:unresolved project:<project>`.
-    /// Use Sentry search syntax directly, e.g.:
-    /// `"release:[so.notion.Mail@1.7.*,so.notion.Mail@1.8.*]"`
+    /// Extra Sentry search filters appended after `is:unresolved` (or
+    /// `is:resolved`). The project filter is passed structurally via the MCP
+    /// `projectSlugOrId` argument — do NOT include `project:<slug>` here, the
+    /// Sentry MCP server's natural-language parser treats it as a soft hint
+    /// only and will let issues from other projects leak through.
+    /// Example: `"error.unhandled:true"` or
+    /// `"release:[so.notion.Mail@1.7.*,so.notion.Mail@1.8.*]"`.
     pub query: String,
     #[serde(default = "default_sentry_min_events")]
     pub min_events: u64,

--- a/src/tracker/mcp_http.rs
+++ b/src/tracker/mcp_http.rs
@@ -71,6 +71,13 @@ impl HttpMcpClient {
         .await
     }
 
+    /// List the tools advertised by the MCP server, including their input schemas.
+    /// Useful for probing/diagnostics; the regular orchestrator only needs the
+    /// names, which `initialize` already logs.
+    pub async fn list_tools(&mut self) -> Result<Value> {
+        self.send_request("tools/list", serde_json::json!({})).await
+    }
+
     async fn send_request(&mut self, method: &str, params: Value) -> Result<Value> {
         let id = self.next_id.fetch_add(1, Ordering::Relaxed);
         let body = serde_json::json!({

--- a/src/tracker/sentry.rs
+++ b/src/tracker/sentry.rs
@@ -18,26 +18,37 @@ impl SentryTracker {
         Ok(Self { config, client })
     }
 
-    /// Build the full Sentry search string.
+    /// Build the filter portion of the Sentry search query.
     ///
-    /// Combines `is:unresolved`/`is:resolved`, `project:<slug>`,
-    /// and the user-supplied `query` from config.
+    /// Combines `is:unresolved`/`is:resolved` with the user-supplied `query`
+    /// from config. The project filter is passed structurally via the
+    /// `projectSlugOrId` argument, NOT inside this string — Sentry's MCP
+    /// server uses a strict JSON schema and a `project:<slug>` token inside
+    /// the freeform `query` is honored only as a soft hint by its NL parser.
     fn build_query(&self, resolved: bool) -> String {
         let status = if resolved { "is:resolved" } else { "is:unresolved" };
-        let project = &self.config.project;
         let extra = &self.config.query;
 
         if extra.is_empty() {
-            format!("project:{project} {status}")
+            status.to_string()
         } else {
-            format!("project:{project} {status} {extra}")
+            format!("{status} {extra}")
         }
     }
 
+    /// Maximum issues to fetch per `search_issues` call. Sentry's MCP schema
+    /// caps `limit` at 100; we always ask for the max so a noisy project
+    /// can't push real targets off the end of a default-10 page.
+    const SEARCH_LIMIT: u64 = 100;
+
     /// Call the `search_issues` MCP tool and parse the markdown response into Issues.
     async fn fetch_issues(&mut self, resolved: bool) -> Result<Vec<Issue>> {
-        let nl_query = self.build_query(resolved);
-        tracing::info!(query = %nl_query, "Sentry MCP query");
+        let query = self.build_query(resolved);
+        tracing::info!(
+            project = %self.config.project,
+            query = %query,
+            "Sentry MCP query",
+        );
 
         let result = self
             .client
@@ -45,7 +56,9 @@ impl SentryTracker {
                 "search_issues",
                 serde_json::json!({
                     "organizationSlug": self.config.org,
-                    "naturalLanguageQuery": nl_query,
+                    "projectSlugOrId": self.config.project,
+                    "query": query,
+                    "limit": Self::SEARCH_LIMIT,
                 }),
             )
             .await?;
@@ -79,6 +92,14 @@ impl SentryTracker {
         // get_issue_details returns a single issue with similar formatting
         let issues = self.parse_issue_list(&text);
         Ok(issues.into_iter().next())
+    }
+
+    /// Expected short-ID prefix for issues belonging to the configured project.
+    /// Sentry generates short IDs as `<PROJECT_SLUG_UPPER>-<HASH>`, so we can
+    /// derive this deterministically and use it as a defense-in-depth filter
+    /// against any future MCP server-side scoping regression.
+    fn expected_short_id_prefix(&self) -> String {
+        format!("{}-", self.config.project.to_ascii_uppercase())
     }
 
     /// Extract the text content from an MCP tool response.
@@ -116,6 +137,7 @@ impl SentryTracker {
     /// ```
     fn parse_issue_list(&self, text: &str) -> Vec<Issue> {
         let mut issues = Vec::new();
+        let expected_prefix = self.expected_short_id_prefix();
 
         // Match issue header: ## N. [SHORT-ID](url)
         let header_re =
@@ -141,6 +163,20 @@ impl SentryTracker {
             if let Some(caps) = header_re.captures(section) {
                 let short_id = caps.get(1).map(|m| m.as_str()).unwrap_or("");
                 let url = caps.get(2).map(|m| m.as_str()).unwrap_or("");
+
+                // Defense-in-depth: even though `projectSlugOrId` is now passed
+                // structurally, drop any issue whose short ID prefix doesn't
+                // match the configured project. Catches both server-side
+                // regressions and the `get_issue_details` path returning an
+                // unexpected project.
+                if !expected_prefix.is_empty() && !short_id.starts_with(&expected_prefix) {
+                    tracing::warn!(
+                        short_id,
+                        expected_prefix,
+                        "Sentry response contained an issue outside the configured project; skipping",
+                    );
+                    continue;
+                }
 
                 let title = Self::extract_bold_line(section);
                 let status = Self::extract_field(section, "Status").unwrap_or_default();
@@ -374,16 +410,18 @@ Found **2** issues:
             ..SentryConfig::default()
         };
 
+        // Project is passed structurally via `projectSlugOrId`, so it must NOT
+        // appear in the query string.
         let query = build_query_standalone(&config, false);
         assert_eq!(
             query,
-            "project:mail-ios is:unresolved release:[so.notion.Mail@1.7.*,so.notion.Mail@1.8.*]"
+            "is:unresolved release:[so.notion.Mail@1.7.*,so.notion.Mail@1.8.*]"
         );
 
         let query = build_query_standalone(&config, true);
         assert_eq!(
             query,
-            "project:mail-ios is:resolved release:[so.notion.Mail@1.7.*,so.notion.Mail@1.8.*]"
+            "is:resolved release:[so.notion.Mail@1.7.*,so.notion.Mail@1.8.*]"
         );
     }
 
@@ -395,7 +433,88 @@ Found **2** issues:
         };
 
         let query = build_query_standalone(&config, false);
-        assert_eq!(query, "project:my-project is:unresolved");
+        assert_eq!(query, "is:unresolved");
+    }
+
+    #[test]
+    fn parse_filters_out_other_projects() {
+        let config = SentryConfig {
+            project: "mail-ios".to_string(),
+            min_events: 1,
+            ..SentryConfig::default()
+        };
+
+        // Mixed response with a mail-ios issue and a mail-web issue. Only the
+        // mail-ios one should survive the client-side prefix guard.
+        let text = r#"## 1. [MAIL-IOS-1A3](https://notion.sentry.io/issues/MAIL-IOS-1A3/)
+
+**iOS crash**
+
+- **Status**: unresolved
+- **Users**: 5
+- **Events**: 42
+- **First seen**: 3 days ago
+- **Last seen**: 2 hours ago
+
+## 2. [MAIL-WEB-9F2](https://notion.sentry.io/issues/MAIL-WEB-9F2/)
+
+**Web crash that should be dropped**
+
+- **Status**: unresolved
+- **Users**: 50
+- **Events**: 500
+- **First seen**: 1 day ago
+- **Last seen**: 30 minutes ago
+
+## 3. [WEBCLIENT-7C1](https://notion.sentry.io/issues/WEBCLIENT-7C1/)
+
+**Other project crash that should be dropped**
+
+- **Status**: unresolved
+- **Users**: 10
+- **Events**: 100
+- **First seen**: 1 day ago
+- **Last seen**: 1 hour ago
+"#;
+
+        let issues = parse_issue_list_standalone(&config, text);
+        assert_eq!(issues.len(), 1);
+        assert_eq!(issues[0].identifier, "sentry:MAIL-IOS-1A3");
+    }
+
+    #[test]
+    fn parse_keeps_everything_when_project_unset() {
+        // Empty project (e.g. tests with default config) means no client-side
+        // filter — preserves prior behavior.
+        let config = SentryConfig {
+            project: String::new(),
+            min_events: 1,
+            ..SentryConfig::default()
+        };
+
+        let text = r#"## 1. [MAIL-IOS-1A3](https://x/MAIL-IOS-1A3/)
+
+**A**
+
+- **Status**: unresolved
+- **Users**: 1
+- **Events**: 1
+- **First seen**: x
+- **Last seen**: y
+
+## 2. [MAIL-WEB-9F2](https://x/MAIL-WEB-9F2/)
+
+**B**
+
+- **Status**: unresolved
+- **Users**: 1
+- **Events**: 1
+- **First seen**: x
+- **Last seen**: y
+"#;
+
+        let issues = parse_issue_list_standalone(&config, text);
+        assert_eq!(issues.len(), 2);
     }
 
     #[test]
@@ -427,6 +546,11 @@ Found **2** issues:
         // Replicate the parsing logic using SentryTracker's static/instance methods.
         // We construct a minimal "tracker" by calling the parse methods directly.
         let mut issues = Vec::new();
+        let expected_prefix = if config.project.is_empty() {
+            String::new()
+        } else {
+            format!("{}-", config.project.to_ascii_uppercase())
+        };
         let header_re = Regex::new(r"##\s+\d+\.\s+\[([^\]]+)\]\(([^)]+)\)").unwrap();
 
         let sections: Vec<(regex::Match, &str)> = {
@@ -448,6 +572,11 @@ Found **2** issues:
             if let Some(caps) = header_re.captures(section) {
                 let short_id = caps.get(1).map(|m| m.as_str()).unwrap_or("");
                 let url = caps.get(2).map(|m| m.as_str()).unwrap_or("");
+
+                if !expected_prefix.is_empty() && !short_id.starts_with(&expected_prefix) {
+                    continue;
+                }
+
                 let title = SentryTracker::extract_bold_line(section);
                 let status =
                     SentryTracker::extract_field(section, "Status").unwrap_or_default();
@@ -512,13 +641,12 @@ Found **2** issues:
     /// Standalone helper to test build_query without an MCP connection.
     fn build_query_standalone(config: &SentryConfig, resolved: bool) -> String {
         let status = if resolved { "is:resolved" } else { "is:unresolved" };
-        let project = &config.project;
         let extra = &config.query;
 
         if extra.is_empty() {
-            format!("project:{project} {status}")
+            status.to_string()
         } else {
-            format!("project:{project} {status} {extra}")
+            format!("{status} {extra}")
         }
     }
 }


### PR DESCRIPTION
## Summary

The Sentry tracker was sending `naturalLanguageQuery` to the MCP `search_issues` tool, but that argument is **not in the tool's schema**. The server silently dropped it, fell back to the default `query: "is:unresolved"`, and returned org-wide results. The `project:<slug>` token inside the freeform string was only honored as a soft NL hint, so issues from other projects (`mail-web`, `webclient`, `ai-api`, …) leaked through and got their own workspaces.

This change sends the schema-correct shape:

- `projectSlugOrId` — hard server-side project scope
- `query` (not `naturalLanguageQuery`) — search filters
- `limit: 100` — server's max; was implicitly 10 before
- Drops `project:<slug>` from the freeform query — it's now structural

It also adds a **defense-in-depth client-side guard** that drops any returned issue whose short-id prefix doesn't match the project's expected uppercase prefix (e.g. `MAIL-IOS-`). If Sentry's MCP server ever regresses or someone re-introduces `project:` into config, we still won't dispatch on the wrong project.

## How this was found

Wrote `examples/sentry_probe.rs`, called `tools/list` against `mcp.sentry.dev` to dump the `search_issues` schema, then ran several argument shapes against the live MCP. Results before/after the fix:

| Variant | Result count | Project prefixes |
|---|---|---|
| Old code (`naturalLanguageQuery: "project:mail-ios is:unresolved error.unhandled:true"`) | 100 | 4 mail-ios, 26 ai-api, 13 api, 55 webclient, 2 collectionapi |
| New code (`projectSlugOrId: "mail-ios"`, `query: "is:unresolved error.unhandled:true"`, `limit: 100`) | 100 | **100 mail-ios, 0 others** |

## Notes / follow-ups

- mail-ios has more than 100 unresolved-unhandled errors right now, so we're hitting the `limit` cap. Each tick processes the top 100 by last-seen date. If older-but-still-active crashes start getting starved, we'll want pagination or a `min_events` server-side filter — separate change.
- `examples/sentry_probe.rs` is kept in-tree as a diagnostic for future Sentry-MCP investigations. It compiles only via `cargo run --example sentry_probe`, so it doesn't affect normal builds.
- `WORKFLOW.sentry.md` is gitignored (per-machine config), but `WORKFLOW.example.md` is updated so new users get the same warning about `project:` in `query`.

## Test plan

- [x] `cargo test` — 90 passed, 0 failed
- [x] `cargo clippy --all-targets` — clean
- [x] Live MCP run against `mcp.sentry.dev` shows 100/100 results carrying the `MAIL-IOS-` prefix
- [x] New unit tests cover the prefix guard (drops cross-project issues; passes through when `project` is unset)