### PR TITLE
Open PRs via workflow_dispatch so review distributes via CODEOWNERS

### DIFF
--- a/WORKFLOW.example.md
+++ b/WORKFLOW.example.md
@@ -177,6 +177,28 @@ review:
 #   # prompt_template: |
 #   #   Address reviewer feedback on PR #{{ issue.extra.pr_number }} for {{ issue.identifier }}.
 #   #   Run `gh pr view {{ issue.extra.pr_number }} --comments` to see feedback.
+
+# Optional: open PRs by triggering a workflow_dispatch GitHub Action in the
+# target repo instead of calling `gh pr create` directly. When set, Symposium
+# pushes the branch and runs `gh workflow run <workflow>` with the title and
+# body as inputs. The Action opens the PR using GITHUB_TOKEN, so it appears
+# authored by `github-actions[bot]` instead of the user Symposium is running
+# under — useful when one human's account would otherwise own every PR and
+# concentrate the review load on the same teammates.
+#
+# An example workflow you can drop into `.github/workflows/open-pr.yml` of your
+# target repo lives at `examples/open-pr.yml` in the symposium repo.
+#
+# Caveat: PRs opened with the default GITHUB_TOKEN do NOT trigger downstream
+# workflow runs (no recursive CI). If your repo needs CI on these PRs, swap in
+# a PAT or GitHub App token inside the workflow itself.
+# pr_creation:
+#   workflow: open-pr.yml          # filename of the workflow_dispatch action in the target repo
+#   branch_input: branch            # workflow input that receives the source branch
+#   title_input: title              # workflow input that receives the PR title
+#   body_input: body                # workflow input that receives the PR body (markdown)
+#   poll_timeout_ms: 120000         # max time to wait for the workflow to open the PR
+#   poll_interval_ms: 3000          # interval between PR-poll attempts
 ---
 ```
 

--- a/examples/open-pr.yml
+++ b/examples/open-pr.yml
@@ -1,0 +1,89 @@
+# Symposium PR opener.
+#
+# Drop this file into your target repo at `.github/workflows/open-pr.yml`,
+# then point Symposium at it from your WORKFLOW.<name>.md:
+#
+#   pr_creation:
+#     workflow: open-pr.yml
+#
+# When Symposium finishes an agent attempt, it pushes the branch and triggers
+# this workflow via `gh workflow run`. The workflow opens the PR using the
+# default `GITHUB_TOKEN`, so the PR is authored by `github-actions[bot]`
+# instead of the user whose credentials Symposium itself runs under. This
+# decouples PR ownership from Symposium's own account so review notifications
+# can be routed via CODEOWNERS independent of who's running the orchestrator.
+#
+# Caveat: PRs opened with the default GITHUB_TOKEN do NOT trigger downstream
+# workflow runs (no recursive CI). If your repo needs CI to run on these PRs,
+# replace `${{ secrets.GITHUB_TOKEN }}` below with a PAT or GitHub App token
+# that has `pull_requests:write` and is exempt from the recursion guard.
+
+name: open-pr
+
+on:
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: "Source branch to open the PR from"
+        required: true
+        type: string
+      title:
+        description: "PR title"
+        required: true
+        type: string
+      body:
+        description: "PR body (markdown)"
+        required: true
+        type: string
+      base:
+        description: "Base branch to merge into"
+        required: false
+        default: "main"
+        type: string
+      draft:
+        description: "Open as a draft"
+        required: false
+        default: "true"
+        type: string
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  open-pr:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.branch }}
+          fetch-depth: 0
+
+      - name: Open PR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_TITLE: ${{ inputs.title }}
+          PR_BODY: ${{ inputs.body }}
+          PR_BASE: ${{ inputs.base }}
+          PR_HEAD: ${{ inputs.branch }}
+          PR_DRAFT: ${{ inputs.draft }}
+        run: |
+          set -euo pipefail
+
+          existing=$(gh pr list --head "$PR_HEAD" --state open --json number --jq '.[0].number' || true)
+          if [ -n "${existing:-}" ]; then
+            echo "PR #$existing is already open for $PR_HEAD; nothing to do."
+            exit 0
+          fi
+
+          args=(
+            --base  "$PR_BASE"
+            --head  "$PR_HEAD"
+            --title "$PR_TITLE"
+            --body  "$PR_BODY"
+          )
+          if [ "$PR_DRAFT" = "true" ]; then
+            args+=( --draft )
+          fi
+
+          gh pr create "${args[@]}"

--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -16,6 +16,7 @@ pub struct ServiceConfig {
     pub preflight: PreflightConfig,
     pub review: ReviewConfig,
     pub pr_review: PrReviewConfig,
+    pub pr_creation: PrCreationConfig,
     pub mcp_servers: HashMap<String, McpServerConfig>,
     pub sentry: SentryConfig,
     pub prompt_template: String,
@@ -372,5 +373,70 @@ impl Default for PrReviewConfig {
             prompt_template: String::new(),
             reviewers: ReviewerFilter::All,
         }
+    }
+}
+
+/// How Symposium should open the PR after the agent commits its work.
+///
+/// By default Symposium calls `gh pr create --draft` directly. That uses the
+/// token Symposium itself was authenticated with, so the PR is authored by
+/// that user and review notifications go to whoever GitHub picks from CODEOWNERS
+/// for that user. In setups where Symposium runs as a single human's account,
+/// every PR concentrates review workload on the same handful of teammates.
+///
+/// Setting `workflow` switches to a `workflow_dispatch` flow: Symposium pushes
+/// the branch and triggers the named GitHub Action in the target repo, passing
+/// the title and body as inputs. The Action opens the PR using `GITHUB_TOKEN`,
+/// so it appears authored by `github-actions[bot]` and review can be routed via
+/// CODEOWNERS independent of whoever is running Symposium.
+///
+/// Caveat: PRs opened with `GITHUB_TOKEN` do not trigger downstream workflow
+/// runs (no recursive CI). Repos that need CI on bot-opened PRs should use a
+/// PAT or a GitHub App token inside the workflow itself.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(default)]
+pub struct PrCreationConfig {
+    /// Filename (or path) of the workflow_dispatch GitHub Action in the target
+    /// repo that opens the PR (e.g. "open-pr.yml"). When empty, Symposium falls
+    /// back to running `gh pr create --draft` directly.
+    pub workflow: String,
+    /// Name of the workflow input that receives the source branch.
+    pub branch_input: String,
+    /// Name of the workflow input that receives the PR title.
+    pub title_input: String,
+    /// Name of the workflow input that receives the PR body.
+    pub body_input: String,
+    /// Maximum time to wait for the workflow to open the PR before giving up.
+    /// Specified in milliseconds. The branch is polled with `gh pr list --head`.
+    pub poll_timeout_ms: u64,
+    /// Interval between PR-poll attempts, in milliseconds.
+    pub poll_interval_ms: u64,
+}
+
+impl Default for PrCreationConfig {
+    fn default() -> Self {
+        Self {
+            workflow: String::new(),
+            branch_input: "branch".to_string(),
+            title_input: "title".to_string(),
+            body_input: "body".to_string(),
+            poll_timeout_ms: 120_000,
+            poll_interval_ms: 3_000,
+        }
+    }
+}
+
+impl PrCreationConfig {
+    /// True when a workflow_dispatch PR-creation flow has been configured.
+    pub fn is_workflow_dispatch(&self) -> bool {
+        !self.workflow.is_empty()
+    }
+
+    pub fn poll_timeout(&self) -> Duration {
+        Duration::from_millis(self.poll_timeout_ms)
+    }
+
+    pub fn poll_interval(&self) -> Duration {
+        Duration::from_millis(self.poll_interval_ms)
     }
 }

--- a/src/config/workflow.rs
+++ b/src/config/workflow.rs
@@ -297,4 +297,54 @@ Prompt here."#;
         assert!(config.pr_review.enabled);
         assert!(config.pr_review.prompt_template.contains("{{ issue.pr_number }}"));
     }
+
+    #[test]
+    fn parse_pr_creation_config_defaults() {
+        let content = "---\n---\nPrompt here.";
+        let (config, _) = parse_workflow(content).unwrap();
+        assert!(!config.pr_creation.is_workflow_dispatch());
+        assert_eq!(config.pr_creation.branch_input, "branch");
+        assert_eq!(config.pr_creation.title_input, "title");
+        assert_eq!(config.pr_creation.body_input, "body");
+        assert_eq!(config.pr_creation.poll_timeout_ms, 120_000);
+        assert_eq!(config.pr_creation.poll_interval_ms, 3_000);
+    }
+
+    #[test]
+    fn parse_pr_creation_config_workflow_dispatch() {
+        let content = r#"---
+pr_creation:
+  workflow: open-pr.yml
+  poll_timeout_ms: 60000
+  poll_interval_ms: 5000
+---
+Prompt here."#;
+        let (config, _) = parse_workflow(content).unwrap();
+        assert!(config.pr_creation.is_workflow_dispatch());
+        assert_eq!(config.pr_creation.workflow, "open-pr.yml");
+        // Unspecified input names retain their defaults.
+        assert_eq!(config.pr_creation.branch_input, "branch");
+        assert_eq!(config.pr_creation.title_input, "title");
+        assert_eq!(config.pr_creation.body_input, "body");
+        assert_eq!(config.pr_creation.poll_timeout_ms, 60_000);
+        assert_eq!(config.pr_creation.poll_interval_ms, 5_000);
+    }
+
+    #[test]
+    fn parse_pr_creation_config_custom_input_names() {
+        let content = r#"---
+pr_creation:
+  workflow: ".github/workflows/dispatch-pr.yml"
+  branch_input: head_ref
+  title_input: pr_title
+  body_input: pr_body
+---
+Prompt here."#;
+        let (config, _) = parse_workflow(content).unwrap();
+        assert!(config.pr_creation.is_workflow_dispatch());
+        assert_eq!(config.pr_creation.workflow, ".github/workflows/dispatch-pr.yml");
+        assert_eq!(config.pr_creation.branch_input, "head_ref");
+        assert_eq!(config.pr_creation.title_input, "pr_title");
+        assert_eq!(config.pr_creation.body_input, "pr_body");
+    }
 }

--- a/src/orchestrator/tick.rs
+++ b/src/orchestrator/tick.rs
@@ -760,22 +760,16 @@ async fn run_worker(
         let (pr_title, pr_body_text) =
             read_pr_metadata(&workspace_dir, &issue).await;
 
-        // Write title/body to temp files outside the workspace to avoid accidental git add
-        let tmp = std::env::temp_dir();
-        let title_file = tmp.join(format!("symposium-pr-title-{}", issue.identifier));
-        let body_file = tmp.join(format!("symposium-pr-body-{}", issue.identifier));
-        if let Err(e) = tokio::fs::write(&title_file, &pr_title).await {
-            tracing::warn!(path = %title_file.display(), "failed to write PR title temp file: {e}");
-        }
-        if let Err(e) = tokio::fs::write(&body_file, &pr_body_text).await {
-            tracing::warn!(path = %body_file.display(), "failed to write PR body temp file: {e}");
-        }
-        let pr_script = format!(
-            "git push -u origin HEAD 2>&1 && gh pr create --draft --title \"$(cat {})\" --body-file {} 2>&1",
-            title_file.display(),
-            body_file.display(),
-        );
-        match hooks::run_hook(&pr_script, &workspace_dir, hook_timeout).await {
+        match open_pr(
+            &issue,
+            &workspace_dir,
+            &config.pr_creation,
+            &pr_title,
+            &pr_body_text,
+            hook_timeout,
+        )
+        .await
+        {
             Ok(()) => {
                 tracing::info!(issue_id = issue.identifier, "draft PR created");
                 state.push_agent_event(
@@ -808,15 +802,145 @@ async fn run_worker(
                 );
             }
         }
-        // Clean up temp files
-        let _ = tokio::fs::remove_file(&title_file).await;
-        let _ = tokio::fs::remove_file(&body_file).await;
     }
 
     // Run after_run hook
     ws.finish(&issue, success).await?;
 
     Ok(success)
+}
+
+/// Push the branch and open a draft PR for the agent's work.
+///
+/// When `pr_creation.workflow` is configured, this triggers a `workflow_dispatch`
+/// GitHub Action in the target repo (passing the title and body as inputs) so the
+/// PR is opened by `github-actions[bot]` and review notifications can be routed
+/// independently of whoever Symposium is authenticated as. Otherwise, falls back
+/// to running `gh pr create --draft` directly with Symposium's own credentials.
+async fn open_pr(
+    issue: &Issue,
+    workspace_dir: &std::path::Path,
+    pr_creation: &crate::config::schema::PrCreationConfig,
+    pr_title: &str,
+    pr_body: &str,
+    hook_timeout: Duration,
+) -> std::result::Result<(), String> {
+    use crate::workspace::hooks as ws_hooks;
+
+    // Write title/body to temp files outside the workspace to avoid accidental git add.
+    let tmp = std::env::temp_dir();
+    let title_file = tmp.join(format!("symposium-pr-title-{}", issue.identifier));
+    let body_file = tmp.join(format!("symposium-pr-body-{}", issue.identifier));
+    if let Err(e) = tokio::fs::write(&title_file, pr_title).await {
+        tracing::warn!(path = %title_file.display(), "failed to write PR title temp file: {e}");
+    }
+    if let Err(e) = tokio::fs::write(&body_file, pr_body).await {
+        tracing::warn!(path = %body_file.display(), "failed to write PR body temp file: {e}");
+    }
+
+    let result = if pr_creation.is_workflow_dispatch() {
+        open_pr_via_workflow_dispatch(
+            workspace_dir,
+            pr_creation,
+            &title_file,
+            &body_file,
+            hook_timeout,
+        )
+        .await
+    } else {
+        let script = format!(
+            "git push -u origin HEAD 2>&1 && gh pr create --draft --title \"$(cat {})\" --body-file {} 2>&1",
+            title_file.display(),
+            body_file.display(),
+        );
+        ws_hooks::run_hook(&script, workspace_dir, hook_timeout)
+            .await
+            .map_err(|e| e.to_string())
+    };
+
+    let _ = tokio::fs::remove_file(&title_file).await;
+    let _ = tokio::fs::remove_file(&body_file).await;
+    result
+}
+
+/// Push the branch, kick off a `workflow_dispatch` GitHub Action that opens the PR,
+/// then poll until the PR is observable on the branch.
+async fn open_pr_via_workflow_dispatch(
+    workspace_dir: &std::path::Path,
+    pr_creation: &crate::config::schema::PrCreationConfig,
+    title_file: &std::path::Path,
+    body_file: &std::path::Path,
+    hook_timeout: Duration,
+) -> std::result::Result<(), String> {
+    use crate::workspace::hooks as ws_hooks;
+
+    // 1. Push the branch upstream so the workflow can resolve it.
+    ws_hooks::run_hook(
+        "git push -u origin HEAD 2>&1",
+        workspace_dir,
+        hook_timeout,
+    )
+    .await
+    .map_err(|e| format!("git push failed: {e}"))?;
+
+    // 2. Resolve the branch name for the workflow input.
+    let branch = ws_hooks::run_hook_with_output(
+        "git rev-parse --abbrev-ref HEAD",
+        workspace_dir,
+        hook_timeout,
+    )
+    .await
+    .map_err(|e| format!("failed to resolve branch name: {e}"))?
+    .trim()
+    .to_string();
+
+    if branch.is_empty() {
+        return Err("git rev-parse returned an empty branch name".into());
+    }
+
+    // 3. Dispatch the workflow. `gh workflow run -F key=@file` reads the value from
+    // the file, which lets us pass multi-line markdown bodies without shell-quoting.
+    let trigger = format!(
+        "gh workflow run \"{workflow}\" -f \"{branch_input}={branch}\" -F \"{title_input}=@{title}\" -F \"{body_input}=@{body}\" 2>&1",
+        workflow = pr_creation.workflow,
+        branch_input = pr_creation.branch_input,
+        branch = branch,
+        title_input = pr_creation.title_input,
+        title = title_file.display(),
+        body_input = pr_creation.body_input,
+        body = body_file.display(),
+    );
+    ws_hooks::run_hook(&trigger, workspace_dir, hook_timeout)
+        .await
+        .map_err(|e| format!("gh workflow run failed: {e}"))?;
+
+    // 4. Poll for the PR. The workflow runs asynchronously on GitHub's side, so the
+    // PR doesn't exist immediately — but we need to know it landed before returning,
+    // so downstream review tracking (`track_created_pr`) can find the PR number.
+    let interval = pr_creation.poll_interval();
+    let timeout = pr_creation.poll_timeout();
+    let probe_timeout = Duration::from_secs(15);
+    let started = std::time::Instant::now();
+    loop {
+        if ws_hooks::run_hook_with_output(
+            "gh pr view --json number 2>/dev/null",
+            workspace_dir,
+            probe_timeout,
+        )
+        .await
+        .is_ok()
+        {
+            return Ok(());
+        }
+        if started.elapsed() >= timeout {
+            return Err(format!(
+                "workflow `{}` was triggered but the PR did not appear within {}s",
+                pr_creation.workflow,
+                timeout.as_secs()
+            ));
+        }
+        tokio::time::sleep(interval).await;
+    }
 }
 
 /// Read agent-generated PR metadata from the workspace, falling back to defaults.


### PR DESCRIPTION
## Summary

Adds an optional `pr_creation` config block. When `pr_creation.workflow` is set, Symposium opens PRs by triggering a `workflow_dispatch` GitHub Action in the target repo (via `gh workflow run`) instead of calling `gh pr create` directly. The Action opens the PR using `GITHUB_TOKEN`, so the PR is authored by `github-actions[bot]`.

## Why

Today, Symposium-generated PRs are authored by whoever Symposium is authenticated as. CODEOWNERS then routes review notifications based on that single user, so the same handful of teammates absorb every Symposium PR. Implements the suggestion from [this Slack thread](https://notion.slack.com/archives/C0A1TQ02EVD/p1777506307413249): if the PR is opened by `github-actions[bot]`, CODEOWNERS distributes review across the actual path owners.

Pairs with the workflow YAML side of the change in [`makenotion/mail#25926`](https://github.com/makenotion/mail/pull/25926).

## What changed

- **`src/config/schema.rs`** — New `PrCreationConfig` (`workflow`, `branch_input`/`title_input`/`body_input`, `poll_timeout_ms`, `poll_interval_ms`). Empty `workflow` keeps the existing `gh pr create` path, so this is fully backwards-compatible — existing WORKFLOW files need no edits.
- **`src/orchestrator/tick.rs`** — Extracted an `open_pr` helper from the inline PR-creation block. When `pr_creation.workflow` is set, Symposium pushes the branch, runs `gh workflow run <wf> -f branch=… -F title=@file -F body=@file`, then polls `gh pr view --json number` until the PR appears (so `track_created_pr` and review monitoring still find it).
- **`examples/open-pr.yml`** — Reference `workflow_dispatch` action for target repos to drop in at `.github/workflows/open-pr.yml`. (The makenotion/mail version is more elaborate but uses the same input contract — both are compatible with default `pr_creation` config.)
- **`WORKFLOW.example.md`** — Documents the new config block, including the `GITHUB_TOKEN`-doesn't-trigger-recursive-CI caveat.
- **`src/config/workflow.rs`** — Three deserialization tests (defaults, populated, custom input names).

## Caveat (documented, not blocking)

PRs opened with the default `GITHUB_TOKEN` do not trigger downstream `pull_request` workflows. If a target repo needs CI on these PRs, the workflow's `GITHUB_TOKEN` should be swapped for a PAT or GitHub App token — Symposium's contract stays the same.

## Out of scope

- `base` / `reviewers` / `assignees` / `labels` pass-through inputs. The reference workflow (and the mail-repo workflow) accept them; Symposium does not currently forward them. Easy follow-up if needed.
- Complexity-labeling and self-review-loop ideas from the Slack thread — those need more conversation first.

## Test plan

- [x] `cargo build` clean
- [x] `cargo test` — 93 passed (3 new for `PrCreationConfig` deserialization)
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [ ] After merge + landing the mail-side workflow: dispatch a real PR end-to-end, confirm `github-actions[bot]` is the author and CODEOWNERS routes review correctly
- [ ] Confirm the poll loop finds the PR within `poll_timeout_ms` under typical Actions queue latency